### PR TITLE
Remove flux autosync of kured

### DIFF
--- a/development-configs/flux-patch.yaml
+++ b/development-configs/flux-patch.yaml
@@ -1,14 +1,3 @@
----
-apiVersion: flux.weave.works/v1beta1
-kind: HelmRelease
-metadata:
-  name: kured
-  namespace: default
-spec:
-  values:
-    image:
-      repository: docker.io/weaveworks/kured:master-f6e4062
----
 apiVersion: flux.weave.works/v1beta1
 kind: HelmRelease
 metadata:

--- a/development-configs/third-party/kured.yaml
+++ b/development-configs/third-party/kured.yaml
@@ -6,8 +6,6 @@ kind: HelmRelease
 metadata:
   name: kured
   namespace: default
-  annotations:
-    flux.weave.works/automated: true
 spec:
   releaseName: "kured"
   chart:


### PR DESCRIPTION
Starting with this commit: https://github.com/equinor/radix-flux/commit/553011fffb2530443758b6aeebbdffb145d3b048

Flux previously auto-updated the incorrect helm values for kured chart causing a broken deploy of kured.

This PR removes the autosync of image-tags from upstream registry.