### PR TITLE
RA-1669: change to radix-image-builder:release-latest tag

### DIFF
--- a/production-configs/radix-platform/radix-operator.yaml
+++ b/production-configs/radix-platform/radix-operator.yaml
@@ -21,6 +21,7 @@ spec:
       repository: radixprod.azurecr.io/radix-operator
       tag: "release-4cbc600ad252dea5796393b017bfbf3b1fd1ee9e"
     activeClusterName: eu-11
+    imageBuilder: radix-image-builder:release-latest
   valuesFrom:
   - configMapKeyRef:
       name: "radix-platform-config"


### PR DESCRIPTION
For radix-image-builder differentiate branch used for dev and playground&prod 

master → used by dev
release → used by playground and prod