### PR TITLE
Update annotations

### DIFF
--- a/development-configs/radix-platform/radix-cost-allocation.yaml
+++ b/development-configs/radix-platform/radix-cost-allocation.yaml
@@ -5,8 +5,8 @@
       name: radix-cost-allocation
       namespace: radix-cost-allocation
       annotations:
-        flux.weave.works/automated: true
-        flux.weave.works/tag.chart-image: glob:master-*
+        fluxcd.io/automated: true
+        filter.fluxcd.io/chart-image: glob:master-*
         helm.fluxcd.io/migrate: "true"
     spec:
       releaseName: "radix-cost-allocation"


### PR DESCRIPTION
Getting some weird errors in the flux pod. 
_"...ReadString: expects \" or n, but found t, error found in #10 byte of ...|tomated\":true,\"fluxc|..."_

Could be caused by deprecated annotations. New annotations described [here](https://docs.fluxcd.io/en/stable/references/helm-operator-integration/)