### PR TITLE
change chart branch to release for acr_cleanup in prod+playground

### DIFF
--- a/playground-configs/radix-platform/radix-acr-cleanup.yaml
+++ b/playground-configs/radix-platform/radix-acr-cleanup.yaml
@@ -15,7 +15,7 @@ spec:
   helmVersion: v3
   chart:
     git: "git@github.com:equinor/radix-acr-cleanup"
-    ref: "master"
+    ref: "release"
     path: "charts/radix-acr-cleanup"
   values:
     registry: radixdev

--- a/production-configs/radix-platform/radix-acr-cleanup.yaml
+++ b/production-configs/radix-platform/radix-acr-cleanup.yaml
@@ -15,7 +15,7 @@ spec:
   helmVersion: v3
   chart:
     git: "git@github.com:equinor/radix-acr-cleanup"
-    ref: "master"
+    ref: "release"
     path: "charts/radix-acr-cleanup"
   values:
     registry: radixprod


### PR DESCRIPTION
Production and playground configs for radix-acr-cleanup mapped to the master branch for the helm chart and to the release branch for container images.

- changed chart reference to release branch for radix-acr-cleanup