### PR TITLE
Update nginx-ingress.yaml

### DIFF
--- a/development-configs/third-party/nginx-ingress.yaml
+++ b/development-configs/third-party/nginx-ingress.yaml
@@ -65,8 +65,8 @@ spec:
         enabled: true
         minReplicas: 2
         maxReplicas: 5
-        targetCPUUtilizationPercentage: 50
-        targetMemoryUtilizationPercentage: 50
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -102,8 +102,8 @@ spec:
       resources:
         limits:
           cpu: "6"
-          memory: 350Mi
+          memory: 500Mi
         requests:
           cpu: 100m
-          memory: 350Mi
+          memory: 500Mi
       priorityClassName: radix-component-priority


### PR DESCRIPTION
pod autoscaler for ingress-nginx in dev starts new pods quite often. I suspect we set target cpu+memory too low.

- increase memory request and limit
- change target mem+cpu for autoscaling to 80%