### PR TITLE
111170 update radix velero plugin

### DIFF
--- a/development-configs/radix-platform/radix-operator.yaml
+++ b/development-configs/radix-platform/radix-operator.yaml
@@ -21,7 +21,7 @@ spec:
       # The following 2 properties are mandatory for Flux image filtering
       repository: radixdev.azurecr.io/radix-operator
       tag: "master-ecfe94aa8d378f1f086f99a12f39443ab286f4c8"
-    activeClusterName: weekly-30
+    activeClusterName: weekly-31
     resources:
       limits:
         cpu: "2"

--- a/development-configs/third-party/velero.yaml
+++ b/development-configs/third-party/velero.yaml
@@ -25,7 +25,7 @@ spec:
       - name: plugins
         mountPath: /target
     - name: radix-velero-plugin
-      image: radixdev.azurecr.io/radix-velero-plugin:latest
+      image: radixdev.azurecr.io/radix-velero-plugin:111170-update-to-go-modules-latest
       volumeMounts:
       - name: plugins
         mountPath: /target

--- a/development-configs/third-party/velero.yaml
+++ b/development-configs/third-party/velero.yaml
@@ -25,7 +25,7 @@ spec:
       - name: plugins
         mountPath: /target
     - name: radix-velero-plugin
-      image: radixdev.azurecr.io/radix-velero-plugin:111170-update-to-go-modules-latest
+      image: radixdev.azurecr.io/radix-velero-plugin:master-latest
       volumeMounts:
       - name: plugins
         mountPath: /target

--- a/playground-configs/third-party/velero.yaml
+++ b/playground-configs/third-party/velero.yaml
@@ -25,7 +25,7 @@ spec:
       - name: plugins
         mountPath: /target
     - name: radix-velero-plugin
-      image: radixdev.azurecr.io/radix-velero-plugin:latest
+      image: radixdev.azurecr.io/radix-velero-plugin:release-latest
       volumeMounts:
       - name: plugins
         mountPath: /target

--- a/production-configs/third-party/velero.yaml
+++ b/production-configs/third-party/velero.yaml
@@ -25,7 +25,7 @@ spec:
       - name: plugins
         mountPath: /target
     - name: radix-velero-plugin
-      image: radixprod.azurecr.io/radix-velero-plugin:latest
+      image: radixprod.azurecr.io/radix-velero-plugin:release-latest
       volumeMounts:
       - name: plugins
         mountPath: /target


### PR DESCRIPTION
Build steps for radix-velero-plugin has changed; push to master builds the image with **master-latest** tag, and push to release builds the image with **release-latest**

This change must be reflected in the velero helmreleases for all environments.
development uses master-latest, and playgroun and production use release-latest