### PR TITLE
operator memory and nonroot

### DIFF
--- a/playground-configs/radix-platform/radix-operator.yaml
+++ b/playground-configs/radix-platform/radix-operator.yaml
@@ -30,7 +30,7 @@ spec:
     resources:
       limits:
         cpu: "2"
-        memory: 1500Mi
+        memory: 3000Mi
       requests:
         cpu: 100m
         memory: 1500Mi

--- a/production-configs/radix-platform/radix-operator.yaml
+++ b/production-configs/radix-platform/radix-operator.yaml
@@ -30,11 +30,11 @@ spec:
     resources:
       limits:
         cpu: "2"
-        memory: 4000Mi
+        memory: 8000Mi
       requests:
         cpu: 100m
-        memory: 3000Mi
-    forceNonRootDeploymentContainers: false
+        memory: 4000Mi
+    forceNonRootDeploymentContainers: true
   valuesFrom:
   - configMapKeyRef:
       name: "radix-platform-config"


### PR DESCRIPTION
- increase radix-operator memory for playground and prod
- enable non-root deployment containers in prod