### PR TITLE
revert dynatrace version to 0.2.3

### DIFF
--- a/clusters/development/overlay/third-party/dynatrace-operator/helmRelease.yaml
+++ b/clusters/development/overlay/third-party/dynatrace-operator/helmRelease.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   chart:
     spec:
-      version: 0.3.0 # https://github.com/Dynatrace/helm-charts/releases
+      version: 0.2.3 # https://github.com/Dynatrace/helm-charts/releases


### PR DESCRIPTION
An issue with the chart makes the helm upgrade fail with flux:
https://github.com/Dynatrace/helm-charts/issues/160