### PR TITLE
add activeClusterName chart value to radix-acr-cleanup

### DIFF
--- a/clusters/development/overlay/radix-platform/radix-acr-cleanup/helmRelease.yaml
+++ b/clusters/development/overlay/radix-platform/radix-acr-cleanup/helmRelease.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   values:
     deleteUntagged: false
+    activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild playground
     image:
       tag: master-c46a182f-1645780285 # {"$imagepolicy": "flux-system:radix-acr-cleanup:tag"}
     resources:

--- a/clusters/playground/overlay/radix-platform/radix-acr-cleanup/helmRelease.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-acr-cleanup/helmRelease.yaml
@@ -7,6 +7,7 @@ spec:
   values:
     deleteUntagged: true
     retainLatestUntagged: 0
+    activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild playground
     image:
       tag: release-5a34a776-1645626038 # {"$imagepolicy": "flux-system:radix-acr-cleanup:tag"}
     resources:

--- a/clusters/production/overlay/radix-platform/radix-acr-cleanup/helmRelease.yaml
+++ b/clusters/production/overlay/radix-platform/radix-acr-cleanup/helmRelease.yaml
@@ -7,6 +7,7 @@ spec:
   values:
     deleteUntagged: true
     retainLatestUntagged: 0
+    activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild playground
     image:
       tag: release-5a34a776-1645626038 # {"$imagepolicy": "flux-system:radix-acr-cleanup:tag"}
     resources:

--- a/components/radix-platform/radix-acr-cleanup/helmRelease.yaml
+++ b/components/radix-platform/radix-acr-cleanup/helmRelease.yaml
@@ -20,6 +20,7 @@ spec:
   values:
     registry: radix${RADIX_ENVIRONMENT}                               # Set by flux patch
     clusterType: ${clusterType}                                       # Read from radix-flux-config configmap
+    activeClusterName: xx                                             # Set by zone-specific overlay
     deleteUntagged: xx                                                # Set by flux patch
     performDelete: true
     period: 1h


### PR DESCRIPTION
activeClusterName required by radix-acr-cleanup, see PR [https://github.com/equinor/radix-acr-cleanup/pull/43](https://github.com/equinor/radix-acr-cleanup/pull/43)