### PR TITLE
update kube-prometheus-stack to 34.0.0

### DIFF
--- a/clusters/development/overlay/third-party/kube-prometheus-stack/helmRelease.yaml
+++ b/clusters/development/overlay/third-party/kube-prometheus-stack/helmRelease.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: 33.1.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
+      version: 34.0.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
   values:
     prometheus:
       prometheusSpec:


### PR DESCRIPTION
Completed pre-task for 33.x to 34.x upgrade:
https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack