### PR TITLE
increase memory limit in prod and c2 clusters

### DIFF
--- a/clusters/c2-production/overlay/radix-platform/radix-vulnerability-scanner/radix-vulnerability-scanner.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-vulnerability-scanner/radix-vulnerability-scanner.yaml
@@ -29,7 +29,7 @@ spec:
             resources:
               limits:
                 cpu: "2"
-                memory: 1500Mi
+                memory: 5000Mi
               requests:
                 cpu: 500m
                 memory: 500Mi

--- a/clusters/production/overlay/radix-platform/radix-vulnerability-scanner/radix-vulnerability-scanner.yaml
+++ b/clusters/production/overlay/radix-platform/radix-vulnerability-scanner/radix-vulnerability-scanner.yaml
@@ -29,7 +29,7 @@ spec:
             resources:
               limits:
                 cpu: "2"
-                memory: 3000Mi
+                memory: 5000Mi
               requests:
                 cpu: 500m
                 memory: 500Mi


### PR DESCRIPTION
Set memory limit to 5000Mi to prevent `snyk container test` to fail on large images. Tested with the largest image in prod cluster.
Technically it would be more stable to set requested memory to 5000Mi, but most images are small and does not consume much memory during scan. To avoid "wasting" memory, we'll try with an increase of only the limit.