### PR TITLE
Update timeframe for acr cleanup in dev clusters

### DIFF
--- a/clusters/development/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
+++ b/clusters/development/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
@@ -32,6 +32,8 @@ spec:
             activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild development
             image:
               tag: ${RADIX_ACR_CLEANUP_TAG} # Set in postBuild development
+            cleanupStart: "06:00"
+            cleanupEnd: "09:00"
             resources:
               limits:
                 cpu: "2"


### PR DESCRIPTION
The default values for cleanup is between 00:00 and 06:00. The dev clusters are stopped in this period, so the cleanup will therefore never run.