### PR TITLE
use oauth-proxy 7.4.0 in dev and playground

### DIFF
--- a/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -53,7 +53,7 @@ spec:
                 limitrange:
                   default:
                     memory: 1000Mi
-            oauthProxyImage: radixdev.azurecr.io/oauth2-proxy:v7.2.1 # https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0 # https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               enforce:
                 level: baseline

--- a/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -59,7 +59,7 @@ spec:
                 limitrange:
                   default:
                     memory: 1000Mi
-            oauthProxyImage: radixdev.azurecr.io/oauth2-proxy:v7.2.1 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               audit:
                 level: baseline


### PR DESCRIPTION
Using newest version of the official oauth2-proxy instead of our own 