### PR TITLE
increase replicas and memory for nginx in prod

### DIFF
--- a/clusters/production/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/production/overlay/third-party/ingress-nginx/patches.yaml
@@ -21,14 +21,14 @@ spec:
             valuesKey: config
           values:
             controller:
-              replicaCount: 8
+              replicaCount: 12
               resources:
                 limits:
                   cpu: "6"
-                  memory: 5000Mi
+                  memory: 6000Mi
                 requests:
                   cpu: 300m
-                  memory: 5000Mi
+                  memory: 6000Mi
               service:
                 annotations:
                   service.beta.kubernetes.io/azure-load-balancer-resource-group: common


### PR DESCRIPTION
nginx ingress controller pods restarts quite often in prod due to OOMKilled. Incresing replicas and memory should help.
