### PR TITLE
Update resources for radix-cost-allocation in production

### DIFF
--- a/clusters/production/overlay/radix-platform/radix-cost-allocation/radix-cost-allocation.yaml
+++ b/clusters/production/overlay/radix-platform/radix-cost-allocation/radix-cost-allocation.yaml
@@ -33,10 +33,10 @@ spec:
             resources:
               limits:
                 cpu: "2"
-                memory: 300Mi
+                memory: 400Mi
               requests:
                 cpu: 100m
-                memory: 300Mi
+                memory: 400Mi
       target:
         kind: HelmRelease
         name: radix-cost-allocation


### PR DESCRIPTION
Pod keeps crash-looping with OOMKilled when mem is 300Mi