### PR TITLE
prod and c2: update oauth2-proxy to 7.6.0

### DIFF
--- a/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -61,7 +61,7 @@ spec:
                 limitrange:
                   default:
                     memory: 500M
-            oauthProxyImage: radixc2prod.azurecr.io/oauth2-proxy:v7.2.1 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               enforce:
                 level: baseline

--- a/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -61,7 +61,7 @@ spec:
                 limitrange:
                   default:
                     memory: 500M
-            oauthProxyImage: radixprod.azurecr.io/oauth2-proxy:v7.2.1 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               enforce:
                 level: baseline


### PR DESCRIPTION
Update oauth2-proxy image for platform and c2