### PR TITLE
configure external dns issuer

### DIFF
--- a/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -72,6 +72,10 @@ spec:
               warn:
                 level: restricted
                 version: v1.23
+            ingress:
+              certificate:
+                automation:
+                  clusterIssuer: digicert-http01
       target:
         kind: HelmRelease
         name: radix-operator


### PR DESCRIPTION
Configure radix-operator to use clusterissuer digicert-http01 when automating cedrtificates for external dns