### PR TITLE
add emptyDir for /tmp used by snyk to store downloaded images

### DIFF
--- a/clusters/development/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/development/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -34,7 +34,7 @@ spec:
                   sizeLimit: 100M
               - name: tmp
                 emptyDir:
-                  sizeLimit: 1G
+                  sizeLimit: 5G
             extraVolumeMounts:
               - name: snyk-cache
                 mountPath: /home/radix-vulnerability-scanner/.cache/snyk

--- a/clusters/development/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/development/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -31,10 +31,15 @@ spec:
             extraVolumes:
               - name: snyk-cache
                 emptyDir:
-                  sizeLimit: 5G
+                  sizeLimit: 100M
+              - name: tmp
+                emptyDir:
+                  sizeLimit: 10G
             extraVolumeMounts:
               - name: snyk-cache
                 mountPath: /home/radix-vulnerability-scanner/.cache/snyk
+              - name: tmp
+                mountPath: /tmp
       target:
         kind: HelmRelease
         name: radix-vulnerability-scanner

--- a/clusters/development/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/development/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -34,7 +34,7 @@ spec:
                   sizeLimit: 100M
               - name: tmp
                 emptyDir:
-                  sizeLimit: 10G
+                  sizeLimit: 1G
             extraVolumeMounts:
               - name: snyk-cache
                 mountPath: /home/radix-vulnerability-scanner/.cache/snyk


### PR DESCRIPTION
Added emptyDir for /tmp where it seems that snyk extracts some data from container image. This is a bit trial&error to see if 100M and 5G is enough. We'll monitor it in dev before releasing to prod