### PR TITLE
use readonly root filesystem for cost allocation

### DIFF
--- a/clusters/c2-production/overlay/radix-platform/radix-cost-allocation/patches.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-cost-allocation/patches.yaml
@@ -24,6 +24,8 @@ spec:
               requests:
                 cpu: 100m
                 memory: 300Mi
+            securityContext:
+              readOnlyRootFilesystem: true                
       target:
         kind: HelmRelease
         name: radix-cost-allocation

--- a/clusters/playground/overlay/radix-platform/radix-cost-allocation/patches.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-cost-allocation/patches.yaml
@@ -24,6 +24,8 @@ spec:
               requests:
                 cpu: 50m
                 memory: 150Mi
+            securityContext:
+              readOnlyRootFilesystem: true                
       target:
         kind: HelmRelease
         name: radix-cost-allocation

--- a/clusters/production/overlay/radix-platform/radix-cost-allocation/patches.yaml
+++ b/clusters/production/overlay/radix-platform/radix-cost-allocation/patches.yaml
@@ -24,6 +24,8 @@ spec:
               requests:
                 cpu: 100m
                 memory: 400Mi
+            securityContext:
+              readOnlyRootFilesystem: true                
       target:
         kind: HelmRelease
         name: radix-cost-allocation


### PR DESCRIPTION
Enables readOnlyRootFilesystem in for radix-cost-allocation in playground, platform and c2