### PR TITLE
remove superfluous spaces

### DIFF
--- a/clusters/playground/overlay/radix-platform/radix-cluster-cleanup/radix-cluster-cleanup.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-cluster-cleanup/radix-cluster-cleanup.yaml
@@ -42,7 +42,7 @@ spec:
                 cpu: 50m
                 memory: 150Mi
             securityContext:
-              readOnlyRootFilesystem: true                
+              readOnlyRootFilesystem: true
       target:
         kind: HelmRelease
         name: radix-cluster-cleanup


### PR DESCRIPTION
The superfluous spaces does not affect functionality, but formatting is weird when doing a `k get ks -oyaml`