### PR TITLE
increase tmp vol for vuln scanner in playground and platform

### DIFF
--- a/clusters/playground/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -34,7 +34,7 @@ spec:
                   sizeLimit: 100M
               - name: tmp
                 emptyDir:
-                  sizeLimit: 5G
+                  sizeLimit: 20G # Required because of a few huge images
             extraVolumeMounts:
               - name: snyk-cache
                 mountPath: /home/radix-vulnerability-scanner/.cache/snyk

--- a/clusters/production/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/production/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -35,7 +35,7 @@ spec:
                   sizeLimit: 100M
               - name: tmp
                 emptyDir:
-                  sizeLimit: 5G
+                  sizeLimit: 80G # Estimating 20GB per worker (because some images are huge) * 4 workers
             extraVolumeMounts:
               - name: snyk-cache
                 mountPath: /home/radix-vulnerability-scanner/.cache/snyk


### PR DESCRIPTION
Currently Kubernetes does not terminatre the pod with exit code 137 when emptyDir quota for /tmp is exceeded. Instead it sends SIGTERM and radix-vulnerability-scanner terminates gracefully with exit code 0. The Pod status is Completed, and the Replicaset controller creates a new Pod instead of restarting the container in the existing Pod.