### PR TITLE
Set readonly filesystem and require non-root for velero init containers (plugins)

### DIFF
--- a/components/third-party/velero/chart/helmRelease.yaml
+++ b/components/third-party/velero/chart/helmRelease.yaml
@@ -27,11 +27,17 @@ spec:
     initContainers:
       - name: velero-plugin-for-microsoft-azure
         image: velero/velero-plugin-for-microsoft-azure:v1.1.1
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         volumeMounts:
           - name: plugins
             mountPath: /target
       - name: radix-velero-plugin
         image: ${velero_plugin_acr_image} # Set in clusters/<cluster>/postBuild
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         volumeMounts:
           - name: plugins
             mountPath: /target


### PR DESCRIPTION
The init containers are used to install velero plugins, like the [radix-velero-plugins](https://github.com/equinor/radix-velero-plugin)