### PR TITLE
enforce supported architecture for nginx default backend service

### DIFF
--- a/clusters/c2-production/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/c2-production/overlay/third-party/ingress-nginx/patches.yaml
@@ -59,6 +59,9 @@ spec:
               extraVolumeMounts:
               - name: custom-error-page
                 mountPath: /www
+              nodeSelector:
+                kubernetes.io/os: linux
+                kubernetes.io/arch: amd64
       target:
         kind: HelmRelease
         name: ingress-nginx

--- a/clusters/playground/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/playground/overlay/third-party/ingress-nginx/patches.yaml
@@ -61,6 +61,9 @@ spec:
               extraVolumeMounts:
               - name: custom-error-page
                 mountPath: /www
+              nodeSelector:
+                kubernetes.io/os: linux
+                kubernetes.io/arch: amd64
       target:
         kind: HelmRelease
         name: ingress-nginx

--- a/clusters/production/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/production/overlay/third-party/ingress-nginx/patches.yaml
@@ -61,6 +61,9 @@ spec:
               extraVolumeMounts:
               - name: custom-error-page
                 mountPath: /www
+              nodeSelector:
+                kubernetes.io/os: linux
+                kubernetes.io/arch: amd64
       target:
         kind: HelmRelease
         name: ingress-nginx


### PR DESCRIPTION
For clusters:
- playground
- platform
- c2