### PR TITLE
dev: force ingress-nginx-controller to run on amd64

### DIFF
--- a/clusters/development/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/development/overlay/third-party/ingress-nginx/patches.yaml
@@ -36,6 +36,9 @@ spec:
                 proxy-buffering: "on"
               extraArgs:
                 default-ssl-certificate: "default/radix-wildcard-tls-cert"
+              nodeSelector:
+                kubernetes.io/os: linux
+                kubernetes.io/arch: amd64
             defaultBackend:
               enabled: true
               resources:


### PR DESCRIPTION
Force nginx to run on amd64 in dev clusters