### PR TITLE
schedule velero on amd64 architecture

### DIFF
--- a/components/third-party/velero/chart/helmRelease.yaml
+++ b/components/third-party/velero/chart/helmRelease.yaml
@@ -64,6 +64,9 @@ spec:
         memory: 256Mi
     containerSecurityContext:
       readOnlyRootFilesystem: true
+    nodeSelector:
+      kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
   valuesFrom:
     - kind: ConfigMap
       name: velero-flux-values


### PR DESCRIPTION
Velero must be scheduled to run on amd64 because the radix-velero-plugin only supports this architecture