### PR TITLE
increase memory limit for vulnerabilirt-scanner in platform to 16Gi

### DIFF
--- a/clusters/production/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/production/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -22,7 +22,7 @@ spec:
             resources:
               limits:
                 cpu: "4"
-                memory: 8Gi
+                memory: 16Gi
               requests:
                 cpu: 500m
                 memory: 4Gi


### PR DESCRIPTION
There are occasional spikes in memory usage that causes OOM. Increasing limit to 16G should hopefully help (according to metrics in grafana)