### PR TITLE
Update Flux Apiversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ metadata:
 spec:
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-operator

--- a/clusters/c2-production/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-acr-cleanup

--- a/clusters/c2-production/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cicd-canary

--- a/clusters/c2-production/overlay/radix-platform/radix-cost-allocation/patches.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-cost-allocation/patches.yaml
@@ -10,7 +10,7 @@ spec:
       radix_cost_allocation_image_tag_prefix: release
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cost-allocation

--- a/clusters/c2-production/overlay/radix-platform/radix-oauth-guard/helmRelease-prometheus.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-oauth-guard/helmRelease-prometheus.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: prometheus-guard

--- a/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -20,7 +20,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-operator

--- a/clusters/c2-production/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -10,7 +10,7 @@ spec:
       radix_vulnerability_scanner_image_tag_prefix: release
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-vulnerability-scanner

--- a/clusters/c2-production/overlay/third-party/azure-workload-identity/helmRelease.yaml
+++ b/clusters/c2-production/overlay/third-party/azure-workload-identity/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: workload-identity-webhook

--- a/clusters/c2-production/overlay/third-party/blob-csi-driver/helmRelease.yaml
+++ b/clusters/c2-production/overlay/third-party/blob-csi-driver/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: blob-csi-driver

--- a/clusters/c2-production/overlay/third-party/cert-manager/patches.yaml
+++ b/clusters/c2-production/overlay/third-party/cert-manager/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: cert-manager
         namespace: cert-manager
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: cert-manager

--- a/clusters/c2-production/overlay/third-party/dynatrace-operator/dynatrace-operator.yaml
+++ b/clusters/c2-production/overlay/third-party/dynatrace-operator/dynatrace-operator.yaml
@@ -12,7 +12,7 @@ spec:
   prune: false
   timeout: 5m0s
   healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: dynatrace-operator
       namespace: dynatrace
@@ -22,7 +22,7 @@ spec:
       namespace: dynatrace
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: dynatrace-operator

--- a/clusters/c2-production/overlay/third-party/external-secrets/patches.yaml
+++ b/clusters/c2-production/overlay/third-party/external-secrets/patches.yaml
@@ -13,7 +13,7 @@ spec:
         - op: replace
           path: /spec/chart/spec/version
           value: ${EXTERNAL_SECRETS} # Set in postBuild development
-#        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+#        apiVersion: helm.toolkit.fluxcd.io/v2
 #        kind: HelmRelease
 #        metadata:
 #          name: external-secrets-operator

--- a/clusters/c2-production/overlay/third-party/grafana/patches.yaml
+++ b/clusters/c2-production/overlay/third-party/grafana/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: grafana
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: grafana

--- a/clusters/c2-production/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/c2-production/overlay/third-party/ingress-nginx/patches.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: ingress-nginx

--- a/clusters/c2-production/overlay/third-party/kube-prometheus-stack/patches.yaml
+++ b/clusters/c2-production/overlay/third-party/kube-prometheus-stack/patches.yaml
@@ -13,7 +13,7 @@ spec:
         name: kube-prometheus-stack
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: kube-prometheus-stack

--- a/clusters/c2-production/overlay/third-party/kubernetes-replicator/helmRelease.yaml
+++ b/clusters/c2-production/overlay/third-party/kubernetes-replicator/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kubernetes-replicator

--- a/clusters/c2-production/overlay/third-party/kured/helmRelease.yaml
+++ b/clusters/c2-production/overlay/third-party/kured/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kured

--- a/clusters/c2-production/overlay/third-party/snyk-monitor/helmRelease.yaml
+++ b/clusters/c2-production/overlay/third-party/snyk-monitor/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: snyk-monitor

--- a/clusters/c2-production/overlay/third-party/velero/patches.yaml
+++ b/clusters/c2-production/overlay/third-party/velero/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: velero
         namespace: velero
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: velero

--- a/clusters/development/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
+++ b/clusters/development/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-acr-cleanup

--- a/clusters/development/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
+++ b/clusters/development/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cicd-canary

--- a/clusters/development/overlay/radix-platform/radix-cluster-cleanup/radix-cluster-cleanup.yaml
+++ b/clusters/development/overlay/radix-platform/radix-cluster-cleanup/radix-cluster-cleanup.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cluster-cleanup

--- a/clusters/development/overlay/radix-platform/radix-cost-allocation/patches.yaml
+++ b/clusters/development/overlay/radix-platform/radix-cost-allocation/patches.yaml
@@ -10,7 +10,7 @@ spec:
       radix_cost_allocation_image_tag_prefix: master
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cost-allocation

--- a/clusters/development/overlay/radix-platform/radix-oauth-guard/helmRelease-prometheus.yaml
+++ b/clusters/development/overlay/radix-platform/radix-oauth-guard/helmRelease-prometheus.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: prometheus-guard

--- a/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -20,7 +20,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-operator

--- a/clusters/development/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/development/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -10,7 +10,7 @@ spec:
       radix_vulnerability_scanner_image_tag_prefix: main
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-vulnerability-scanner

--- a/clusters/development/overlay/third-party/azure-workload-identity/helmRelease.yaml
+++ b/clusters/development/overlay/third-party/azure-workload-identity/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: workload-identity-webhook

--- a/clusters/development/overlay/third-party/blob-csi-driver/helmRelease.yaml
+++ b/clusters/development/overlay/third-party/blob-csi-driver/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: blob-csi-driver

--- a/clusters/development/overlay/third-party/cert-manager/patches.yaml
+++ b/clusters/development/overlay/third-party/cert-manager/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: cert-manager
         namespace: cert-manager
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: cert-manager

--- a/clusters/development/overlay/third-party/dynatrace-operator/dynatrace-operator.yaml
+++ b/clusters/development/overlay/third-party/dynatrace-operator/dynatrace-operator.yaml
@@ -12,7 +12,7 @@ spec:
   prune: false
   timeout: 5m0s
   healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: dynatrace-operator
       namespace: dynatrace
@@ -22,7 +22,7 @@ spec:
       namespace: dynatrace
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: dynatrace-operator

--- a/clusters/development/overlay/third-party/external-secrets/patches.yaml
+++ b/clusters/development/overlay/third-party/external-secrets/patches.yaml
@@ -13,7 +13,7 @@ spec:
         - op: replace
           path: /spec/chart/spec/version
           value: ${EXTERNAL_SECRETS} # Set in postBuild development
-#        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+#        apiVersion: helm.toolkit.fluxcd.io/v2
 #        kind: HelmRelease
 #        metadata:
 #          name: external-secrets-operator

--- a/clusters/development/overlay/third-party/grafana-loki/helmRelease.yaml
+++ b/clusters/development/overlay/third-party/grafana-loki/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: loki-stack

--- a/clusters/development/overlay/third-party/grafana/patches.yaml
+++ b/clusters/development/overlay/third-party/grafana/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: grafana
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: grafana

--- a/clusters/development/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/development/overlay/third-party/ingress-nginx/patches.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: ingress-nginx

--- a/clusters/development/overlay/third-party/kube-prometheus-stack/patches.yaml
+++ b/clusters/development/overlay/third-party/kube-prometheus-stack/patches.yaml
@@ -13,7 +13,7 @@ spec:
         name: kube-prometheus-stack
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: kube-prometheus-stack

--- a/clusters/development/overlay/third-party/kubernetes-replicator/helmRelease.yaml
+++ b/clusters/development/overlay/third-party/kubernetes-replicator/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kubernetes-replicator

--- a/clusters/development/overlay/third-party/kured/helmRelease.yaml
+++ b/clusters/development/overlay/third-party/kured/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kured

--- a/clusters/development/overlay/third-party/snyk-monitor/helmRelease.yaml
+++ b/clusters/development/overlay/third-party/snyk-monitor/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: snyk-monitor

--- a/clusters/development/overlay/third-party/velero/patches.yaml
+++ b/clusters/development/overlay/third-party/velero/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: velero
         namespace: velero
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: velero

--- a/clusters/monitoring/overlay/third-party/cert-manager/patches.yaml
+++ b/clusters/monitoring/overlay/third-party/cert-manager/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: cert-manager
         namespace: cert-manager
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: cert-manager

--- a/clusters/monitoring/overlay/third-party/external-secrets/patches.yaml
+++ b/clusters/monitoring/overlay/third-party/external-secrets/patches.yaml
@@ -13,7 +13,7 @@ spec:
         - op: replace
           path: /spec/chart/spec/version
           value: ${EXTERNAL_SECRETS} # Set in postBuild development
-#        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+#        apiVersion: helm.toolkit.fluxcd.io/v2
 #        kind: HelmRelease
 #        metadata:
 #          name: external-secrets-operator

--- a/clusters/monitoring/overlay/third-party/grafana/patches.yaml
+++ b/clusters/monitoring/overlay/third-party/grafana/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: grafana
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: grafana

--- a/clusters/monitoring/overlay/third-party/ingress-nginx/helmRelease.yaml
+++ b/clusters/monitoring/overlay/third-party/ingress-nginx/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ingress-nginx

--- a/clusters/monitoring/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/monitoring/overlay/third-party/ingress-nginx/patches.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: ingress-nginx

--- a/clusters/monitoring/overlay/third-party/kube-prometheus-stack/patches.yaml
+++ b/clusters/monitoring/overlay/third-party/kube-prometheus-stack/patches.yaml
@@ -13,7 +13,7 @@ spec:
         name: kube-prometheus-stack
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: kube-prometheus-stack

--- a/clusters/monitoring/overlay/third-party/prometheus-blackbox-exporter/helmRelease.yaml
+++ b/clusters/monitoring/overlay/third-party/prometheus-blackbox-exporter/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: prometheus-blackbox-exporter

--- a/clusters/playground/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-acr-cleanup

--- a/clusters/playground/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cicd-canary

--- a/clusters/playground/overlay/radix-platform/radix-cluster-cleanup/radix-cluster-cleanup.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-cluster-cleanup/radix-cluster-cleanup.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cluster-cleanup

--- a/clusters/playground/overlay/radix-platform/radix-cost-allocation/patches.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-cost-allocation/patches.yaml
@@ -10,7 +10,7 @@ spec:
       radix_cost_allocation_image_tag_prefix: release
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cost-allocation

--- a/clusters/playground/overlay/radix-platform/radix-oauth-guard/helmRelease-prometheus.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-oauth-guard/helmRelease-prometheus.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: prometheus-guard

--- a/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -20,7 +20,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-operator

--- a/clusters/playground/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -10,7 +10,7 @@ spec:
       radix_vulnerability_scanner_image_tag_prefix: release
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-vulnerability-scanner

--- a/clusters/playground/overlay/third-party/azure-workload-identity/helmRelease.yaml
+++ b/clusters/playground/overlay/third-party/azure-workload-identity/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: workload-identity-webhook

--- a/clusters/playground/overlay/third-party/blob-csi-driver/helmRelease.yaml
+++ b/clusters/playground/overlay/third-party/blob-csi-driver/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: blob-csi-driver

--- a/clusters/playground/overlay/third-party/cert-manager/patches.yaml
+++ b/clusters/playground/overlay/third-party/cert-manager/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: cert-manager
         namespace: cert-manager
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: cert-manager

--- a/clusters/playground/overlay/third-party/dynatrace-operator/dynatrace-operator.yaml
+++ b/clusters/playground/overlay/third-party/dynatrace-operator/dynatrace-operator.yaml
@@ -12,7 +12,7 @@ spec:
   prune: false
   timeout: 5m0s
   healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: dynatrace-operator
       namespace: dynatrace
@@ -22,7 +22,7 @@ spec:
       namespace: dynatrace
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: dynatrace-operator

--- a/clusters/playground/overlay/third-party/external-secrets/patches.yaml
+++ b/clusters/playground/overlay/third-party/external-secrets/patches.yaml
@@ -13,7 +13,7 @@ spec:
         - op: replace
           path: /spec/chart/spec/version
           value: ${EXTERNAL_SECRETS} # Set in postBuild development
-#        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+#        apiVersion: helm.toolkit.fluxcd.io/v2
 #        kind: HelmRelease
 #        metadata:
 #          name: external-secrets-operator

--- a/clusters/playground/overlay/third-party/grafana/patches.yaml
+++ b/clusters/playground/overlay/third-party/grafana/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: grafana
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: grafana

--- a/clusters/playground/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/playground/overlay/third-party/ingress-nginx/patches.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: ingress-nginx

--- a/clusters/playground/overlay/third-party/kube-prometheus-stack/patches.yaml
+++ b/clusters/playground/overlay/third-party/kube-prometheus-stack/patches.yaml
@@ -13,7 +13,7 @@ spec:
         name: kube-prometheus-stack
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: kube-prometheus-stack

--- a/clusters/playground/overlay/third-party/kubernetes-replicator/helmRelease.yaml
+++ b/clusters/playground/overlay/third-party/kubernetes-replicator/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kubernetes-replicator

--- a/clusters/playground/overlay/third-party/snyk-monitor/helmRelease.yaml
+++ b/clusters/playground/overlay/third-party/snyk-monitor/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: snyk-monitor

--- a/clusters/playground/overlay/third-party/velero/patches.yaml
+++ b/clusters/playground/overlay/third-party/velero/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: velero
         namespace: velero
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: velero

--- a/clusters/production/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
+++ b/clusters/production/overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-acr-cleanup

--- a/clusters/production/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
+++ b/clusters/production/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
@@ -21,7 +21,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cicd-canary

--- a/clusters/production/overlay/radix-platform/radix-cost-allocation/patches.yaml
+++ b/clusters/production/overlay/radix-platform/radix-cost-allocation/patches.yaml
@@ -10,7 +10,7 @@ spec:
       radix_cost_allocation_image_tag_prefix: release
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-cost-allocation

--- a/clusters/production/overlay/radix-platform/radix-oauth-guard/helmRelease-prometheus.yaml
+++ b/clusters/production/overlay/radix-platform/radix-oauth-guard/helmRelease-prometheus.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: prometheus-guard

--- a/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -20,7 +20,7 @@ spec:
         name: radix-flux-config
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-operator

--- a/clusters/production/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
+++ b/clusters/production/overlay/radix-platform/radix-vulnerability-scanner/patches.yaml
@@ -10,7 +10,7 @@ spec:
       radix_vulnerability_scanner_image_tag_prefix: release
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: radix-vulnerability-scanner

--- a/clusters/production/overlay/third-party/azure-workload-identity/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/azure-workload-identity/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: workload-identity-webhook

--- a/clusters/production/overlay/third-party/blob-csi-driver/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/blob-csi-driver/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: blob-csi-driver

--- a/clusters/production/overlay/third-party/cert-manager/patches.yaml
+++ b/clusters/production/overlay/third-party/cert-manager/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: cert-manager
         namespace: cert-manager
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: cert-manager

--- a/clusters/production/overlay/third-party/dynatrace-operator/dynatrace-operator.yaml
+++ b/clusters/production/overlay/third-party/dynatrace-operator/dynatrace-operator.yaml
@@ -12,7 +12,7 @@ spec:
   prune: false
   timeout: 5m0s
   healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: dynatrace-operator
       namespace: dynatrace
@@ -22,7 +22,7 @@ spec:
       namespace: dynatrace
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: dynatrace-operator

--- a/clusters/production/overlay/third-party/external-secrets/patches.yaml
+++ b/clusters/production/overlay/third-party/external-secrets/patches.yaml
@@ -13,7 +13,7 @@ spec:
         - op: replace
           path: /spec/chart/spec/version
           value: ${EXTERNAL_SECRETS} # Set in postBuild development
-#        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+#        apiVersion: helm.toolkit.fluxcd.io/v2
 #        kind: HelmRelease
 #        metadata:
 #          name: external-secrets-operator

--- a/clusters/production/overlay/third-party/grafana/patches.yaml
+++ b/clusters/production/overlay/third-party/grafana/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: grafana
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: grafana

--- a/clusters/production/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/production/overlay/third-party/ingress-nginx/patches.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: ingress-nginx

--- a/clusters/production/overlay/third-party/kube-prometheus-stack/patches.yaml
+++ b/clusters/production/overlay/third-party/kube-prometheus-stack/patches.yaml
@@ -13,7 +13,7 @@ spec:
         name: kube-prometheus-stack
         namespace: monitor
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: kube-prometheus-stack

--- a/clusters/production/overlay/third-party/kubernetes-replicator/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/kubernetes-replicator/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kubernetes-replicator

--- a/clusters/production/overlay/third-party/kured/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/kured/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kured

--- a/clusters/production/overlay/third-party/snyk-monitor/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/snyk-monitor/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: snyk-monitor

--- a/clusters/production/overlay/third-party/velero/patches.yaml
+++ b/clusters/production/overlay/third-party/velero/patches.yaml
@@ -10,7 +10,7 @@ spec:
         name: velero
         namespace: velero
       patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: velero

--- a/components/radix-platform/radix-acr-cleanup/helmRelease.yaml
+++ b/components/radix-platform/radix-acr-cleanup/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: radix-acr-cleanup

--- a/components/radix-platform/radix-cicd-canary/helmRelease.yaml
+++ b/components/radix-platform/radix-cicd-canary/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: radix-cicd-canary

--- a/components/radix-platform/radix-cluster-cleanup/helmRelease.yaml
+++ b/components/radix-platform/radix-cluster-cleanup/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: radix-cluster-cleanup

--- a/components/radix-platform/radix-cost-allocation/app/helmRelease.yaml
+++ b/components/radix-platform/radix-cost-allocation/app/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: radix-cost-allocation

--- a/components/radix-platform/radix-oauth-guard/helmRepo.yaml
+++ b/components/radix-platform/radix-oauth-guard/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: radix-oauth-guard

--- a/components/radix-platform/radix-operator/helmRelease.yaml
+++ b/components/radix-platform/radix-operator/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: radix-operator

--- a/components/radix-platform/radix-vulnerability-scanner/app/helmRelease.yaml
+++ b/components/radix-platform/radix-vulnerability-scanner/app/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: radix-vulnerability-scanner

--- a/components/third-party/azure-service-operator/chart/helmRelease.yaml
+++ b/components/third-party/azure-service-operator/chart/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: azure-service-operator

--- a/components/third-party/azure-service-operator/chart/helmRepo.yaml
+++ b/components/third-party/azure-service-operator/chart/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: azure-service-operator

--- a/components/third-party/azure-workload-identity/helmRelease.yaml
+++ b/components/third-party/azure-workload-identity/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: workload-identity-webhook

--- a/components/third-party/azure-workload-identity/helmRepo.yaml
+++ b/components/third-party/azure-workload-identity/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: azure-workload-identity

--- a/components/third-party/blob-csi-driver/helmRelease.yaml
+++ b/components/third-party/blob-csi-driver/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: blob-csi-driver

--- a/components/third-party/blob-csi-driver/helmRepo.yaml
+++ b/components/third-party/blob-csi-driver/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: blob-csi-driver

--- a/components/third-party/cert-manager/chart/helmRelease.yaml
+++ b/components/third-party/cert-manager/chart/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cert-manager

--- a/components/third-party/cert-manager/chart/helmRepo.yaml
+++ b/components/third-party/cert-manager/chart/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cert-manager

--- a/components/third-party/dynatrace-operator/helmRelease.yaml
+++ b/components/third-party/dynatrace-operator/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: dynatrace-operator

--- a/components/third-party/dynatrace-operator/helmRepo.yaml
+++ b/components/third-party/dynatrace-operator/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: dynatrace-operator

--- a/components/third-party/external-secrets/operator/helmRelease.yaml
+++ b/components/third-party/external-secrets/operator/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: external-secrets-operator

--- a/components/third-party/external-secrets/operator/helmRepo.yaml
+++ b/components/third-party/external-secrets/operator/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: external-secrets-operator

--- a/components/third-party/grafana-loki/helmRelease.yaml
+++ b/components/third-party/grafana-loki/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: loki-stack

--- a/components/third-party/grafana-loki/helmRepo.yaml
+++ b/components/third-party/grafana-loki/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana-loki

--- a/components/third-party/grafana/chart/helmRelease.yaml
+++ b/components/third-party/grafana/chart/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: grafana

--- a/components/third-party/grafana/chart/helmRepo.yaml
+++ b/components/third-party/grafana/chart/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana

--- a/components/third-party/ingress-nginx-monitoring/helmRelease.yaml
+++ b/components/third-party/ingress-nginx-monitoring/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ingress-nginx

--- a/components/third-party/ingress-nginx-monitoring/helmRepo.yaml
+++ b/components/third-party/ingress-nginx-monitoring/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: ingress-nginx

--- a/components/third-party/ingress-nginx/chart.yaml
+++ b/components/third-party/ingress-nginx/chart.yaml
@@ -12,7 +12,7 @@ spec:
     name: flux-system
   timeout: 2m0s
   healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: ingress-nginx
       namespace: ingress-nginx

--- a/components/third-party/ingress-nginx/chart/helmRelease.yaml
+++ b/components/third-party/ingress-nginx/chart/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ingress-nginx

--- a/components/third-party/ingress-nginx/chart/helmRepo.yaml
+++ b/components/third-party/ingress-nginx/chart/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: ingress-nginx

--- a/components/third-party/keda/helmRelease.yaml
+++ b/components/third-party/keda/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: keda

--- a/components/third-party/keda/helmRepo.yaml
+++ b/components/third-party/keda/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: keda

--- a/components/third-party/kube-prometheus-stack/chart/helmRelease.yaml
+++ b/components/third-party/kube-prometheus-stack/chart/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/components/third-party/kube-prometheus-stack/chart/helmRepo.yaml
+++ b/components/third-party/kube-prometheus-stack/chart/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kube-prometheus-stack

--- a/components/third-party/kubed/helmRelease.yaml
+++ b/components/third-party/kubed/helmRelease.yaml
@@ -3,7 +3,7 @@
 # Since we have not enabled notifications from kubed, we can hardcode clusterName for all dev clusters
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kubed

--- a/components/third-party/kubed/helmRepo.yaml
+++ b/components/third-party/kubed/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kubed

--- a/components/third-party/kubernetes-replicator/helmRelease.yaml
+++ b/components/third-party/kubernetes-replicator/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kubernetes-replicator

--- a/components/third-party/kubernetes-replicator/helmRepo.yaml
+++ b/components/third-party/kubernetes-replicator/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kubernetes-replicator

--- a/components/third-party/kured/helmRelease.yaml
+++ b/components/third-party/kured/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   annotations:

--- a/components/third-party/kured/helmRepo.yaml
+++ b/components/third-party/kured/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kured

--- a/components/third-party/prometheus-blackbox-exporter/helmRelease.yaml
+++ b/components/third-party/prometheus-blackbox-exporter/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: prometheus-blackbox-exporter

--- a/components/third-party/prometheus-blackbox-exporter/helmRepo.yaml
+++ b/components/third-party/prometheus-blackbox-exporter/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-blackbox-exporter

--- a/components/third-party/snyk-monitor/helmRelease.yaml
+++ b/components/third-party/snyk-monitor/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: snyk-monitor

--- a/components/third-party/snyk-monitor/helmRepo.yaml
+++ b/components/third-party/snyk-monitor/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: snyk-charts

--- a/components/third-party/tekton/helmRelease.yaml
+++ b/components/third-party/tekton/helmRelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tekton-pipelines

--- a/components/third-party/velero/chart/helmRelease.yaml
+++ b/components/third-party/velero/chart/helmRelease.yaml
@@ -1,6 +1,6 @@
 # For velero chart doc see https://github.com/vmware-tanzu/helm-charts
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: velero

--- a/components/third-party/velero/chart/helmRepo.yaml
+++ b/components/third-party/velero/chart/helmRepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: velero


### PR DESCRIPTION
Done in accordance with https://fluxcd.io/blog/2024/05/flux-v2.3.0/#general-availability-of-flux-helm-features-and-apis
Done in steps:

- [ ] dev
- [ ] playground
- [ ] platform
- [ ] c2
- [ ] extmon
