### PR TITLE
create external secret for radix-registry-default-auth

### DIFF
--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: configure-secret-radix-registry-default-auth
+    branch: master
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: master
+    branch: configure-secret-radix-registry-default-auth
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/components/flux/externalsecrets/secrets/secret.yaml
+++ b/components/flux/externalsecrets/secrets/secret.yaml
@@ -85,5 +85,5 @@ spec:
       key: docker-io-auth-username
   - secretKey: password
     remoteRef:
-      key: docker-io-auth-password
+      key: docker-io-auth-access-token
 

--- a/components/flux/externalsecrets/secrets/secret.yaml
+++ b/components/flux/externalsecrets/secrets/secret.yaml
@@ -77,7 +77,10 @@ spec:
       #     replicator.v1.mittwald.de/replicate-to-matching: radix-app
       #   labels: {}
       data:
-        .dockerconfigjson: "{{ .username | upper }}"
+        .dockerconfigjson: |
+          datasources:
+          - name: a
+          - name: "{{ .username }}"
   data:
   - secretKey: username
     remoteRef:

--- a/components/flux/externalsecrets/secrets/secret.yaml
+++ b/components/flux/externalsecrets/secrets/secret.yaml
@@ -69,13 +69,13 @@ spec:
   secretStoreRef:
     name: radix-keyvault
     kind: ClusterSecretStore
-  refreshInterval: "1h"
+  refreshInterval: 5m
   target:
     template:
-      # metadata:
-      #   annotations:
-      #     replicator.v1.mittwald.de/replicate-to-matching: radix-app
-      #   labels: {}
+      engineVersion: v2
+      metadata:
+        annotations:
+          replicator.v1.mittwald.de/replicate-to-matching: radix-app
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: '{"auths":{"docker.io":{"username":"{{ .username }}","password":"{{ .password }}","auth":"{{ printf "%s:%s" .username .password | b64enc }}"}}}'

--- a/components/flux/externalsecrets/secrets/secret.yaml
+++ b/components/flux/externalsecrets/secrets/secret.yaml
@@ -63,7 +63,7 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: radix-registry-default-auth
+  name: radix-external-registry-default-auth
   namespace: default
 spec:
   secretStoreRef:

--- a/components/flux/externalsecrets/secrets/secret.yaml
+++ b/components/flux/externalsecrets/secrets/secret.yaml
@@ -76,6 +76,7 @@ spec:
       #   annotations:
       #     replicator.v1.mittwald.de/replicate-to-matching: radix-app
       #   labels: {}
+      type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: '{"auths":{"docker.io":{"username":"{{ .username }}","password":"{{ .password }}","auth":"{{ printf "%s:%s" .username .password | b64enc }}"}}}'
   data:

--- a/components/flux/externalsecrets/secrets/secret.yaml
+++ b/components/flux/externalsecrets/secrets/secret.yaml
@@ -77,7 +77,7 @@ spec:
       #     replicator.v1.mittwald.de/replicate-to-matching: radix-app
       #   labels: {}
       data:
-        .dockerconfigjson: "{{ `{{ .username | upper }}` }}"
+        .dockerconfigjson: "{{ .username | upper }}"
   data:
   - secretKey: username
     remoteRef:

--- a/components/flux/externalsecrets/secrets/secret.yaml
+++ b/components/flux/externalsecrets/secrets/secret.yaml
@@ -41,6 +41,7 @@ spec:
   refreshInterval: "1h"
   target:
     template:
+
       metadata:
         annotations:
           replicator.v1.mittwald.de/replicate-to-matching: radix-env=app
@@ -57,3 +58,29 @@ spec:
     remoteRef:
       key: radix-cr-cicd
       property: password
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: radix-registry-default-auth
+  namespace: default
+spec:
+  secretStoreRef:
+    name: radix-keyvault
+    kind: ClusterSecretStore
+  refreshInterval: "1h"
+  target:
+    template:
+      # metadata:
+      #   annotations:
+      #     replicator.v1.mittwald.de/replicate-to-matching: radix-app
+      #   labels: {}
+      data:
+        .dockerconfigjson: "{{ `{{ .username | upper }}` }}"
+  data:
+  - secretKey: username
+    remoteRef:
+      key: radix-cr-cicd
+      property: id
+

--- a/components/flux/externalsecrets/secrets/secret.yaml
+++ b/components/flux/externalsecrets/secrets/secret.yaml
@@ -77,13 +77,12 @@ spec:
       #     replicator.v1.mittwald.de/replicate-to-matching: radix-app
       #   labels: {}
       data:
-        .dockerconfigjson: |
-          datasources:
-          - name: a
-          - name: "{{ .username }}"
+        .dockerconfigjson: '{"auths":{"docker.io":{"username":"{{ .username }}","password":"{{ .password }}","auth":"{{ printf "%s:%s" .username .password | b64enc }}"}}}'
   data:
   - secretKey: username
     remoteRef:
-      key: radix-cr-cicd
-      property: id
+      key: docker-io-auth-username
+  - secretKey: password
+    remoteRef:
+      key: docker-io-auth-password
 


### PR DESCRIPTION
The referenced key vault secrets are created for all environments (dev, playground, prod and c2)