### PR TITLE
set buildkitImageBuilder for playground, platform and c2

### DIFF
--- a/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -31,6 +31,7 @@ spec:
               tag: ${RADIX_OPERATOR_TAG} # Set in postBuild production
             activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild production
             imageBuilder: radix-image-builder:release-latest
+            buildkitImageBuilder: radix-buildkit-builder:release-latest
             imageScanner: radix-image-scanner:release-latest
             configToMap: radix-config-2-map:release-latest
             radixTekton: radix-tekton:release-latest

--- a/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -32,8 +32,6 @@ spec:
             activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild production
             imageBuilder: radix-image-builder:release-latest
             buildkitImageBuilder: radix-buildkit-builder:release-latest
-            imageScanner: radix-image-scanner:release-latest
-            configToMap: radix-config-2-map:release-latest
             radixTekton: radix-tekton:release-latest
             jobScheduler: radix-job-scheduler:release-latest
             containerRegistry: ${radix_acr_repo_url} # Set in postBuild production

--- a/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -30,6 +30,12 @@ spec:
             image:
               tag: ${RADIX_OPERATOR_TAG} # Set in postBuild development
             activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild development
+            imageBuilder: radix-image-builder:master-latest
+            buildKitImageBuilder: radix-buildkit-builder:main-latest
+            radixTekton: radix-tekton:main-latest
+            jobScheduler: radix-job-scheduler:main-latest
+            containerRegistry: ${radix_acr_repo_url}
+            appContainerRegistry: ${RADIX_APP_ACR_REPO_URL}
             radixZone: ${RADIX_ZONE} # Set in postBuild development
             resources:
               limits:
@@ -47,8 +53,6 @@ spec:
             alertControllerThreads: 21
             kubeClientRateLimitBurst: 500
             kubeClientRateLimitQPS: 500
-            containerRegistry: ${radix_acr_repo_url}
-            appContainerRegistry: ${RADIX_APP_ACR_REPO_URL}
             buildahImageBuilder: ${RADIX_BUILDAH_IMAGE_BUILDER_IMAGE}  # Set in postBuild development
             gitCloneNsLookupImage: ${RADIX_PIPELINE_GIT_CLONE_NSLOOKUP_IMAGE}  # Set in postBuild development
             gitCloneGitImage: ${RADIX_PIPELINE_GIT_CLONE_GIT_IMAGE}  # Set in postBuild development

--- a/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -31,6 +31,7 @@ spec:
               tag: ${RADIX_OPERATOR_TAG} # Set in postBuild playground
             activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild playground
             imageBuilder: radix-image-builder:release-latest
+            buildkitImageBuilder: radix-buildkit-builder:release-latest
             imageScanner: radix-image-scanner:release-latest
             configToMap: radix-config-2-map:release-latest
             radixTekton: radix-tekton:release-latest

--- a/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -32,8 +32,6 @@ spec:
             activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild playground
             imageBuilder: radix-image-builder:release-latest
             buildkitImageBuilder: radix-buildkit-builder:release-latest
-            imageScanner: radix-image-scanner:release-latest
-            configToMap: radix-config-2-map:release-latest
             radixTekton: radix-tekton:release-latest
             jobScheduler: radix-job-scheduler:release-latest
             containerRegistry: ${radix_acr_repo_url}

--- a/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -31,6 +31,7 @@ spec:
               tag: ${RADIX_OPERATOR_TAG} # Set in postBuild production
             activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild production
             imageBuilder: radix-image-builder:release-latest
+            buildkitImageBuilder: radix-buildkit-builder:release-latest
             imageScanner: radix-image-scanner:release-latest
             configToMap: radix-config-2-map:release-latest
             radixTekton: radix-tekton:release-latest

--- a/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -32,8 +32,6 @@ spec:
             activeClusterName: ${ACTIVE_CLUSTER} # Set in postBuild production
             imageBuilder: radix-image-builder:release-latest
             buildkitImageBuilder: radix-buildkit-builder:release-latest
-            imageScanner: radix-image-scanner:release-latest
-            configToMap: radix-config-2-map:release-latest
             radixTekton: radix-tekton:release-latest
             jobScheduler: radix-job-scheduler:release-latest
             containerRegistry: ${radix_acr_repo_url} # Set in postBuild production


### PR DESCRIPTION
Override buildkitImageBuilder in radix-operator helm chart for playground, platform and c2.

Development cluster uses default helm value, the same way as for imageBuilder 