### PR TITLE
update oauth2-proxy image to v7.7.1 (development cluster)

### DIFF
--- a/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -69,7 +69,7 @@ spec:
                     memory: 3000M
                   requests:
                     memory: 700M
-            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0 # https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1 # https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               enforce:
                 level: baseline


### PR DESCRIPTION
Fixes several high and critical vulneabilities present in v7.6.0