### PR TITLE
update oauth2-proxy to v7.7.1

### DIFF
--- a/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -64,7 +64,7 @@ spec:
                 limitrange:
                   default:
                     memory: 500M
-            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               enforce:
                 level: baseline

--- a/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -64,7 +64,7 @@ spec:
                 limitrange:
                   default:
                     memory: 500M
-            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               enforce:
                 level: baseline

--- a/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -64,7 +64,7 @@ spec:
                 limitrange:
                   default:
                     memory: 500M
-            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               enforce:
                 level: baseline


### PR DESCRIPTION
fixes multiple high and critical vulnerabilities

already deployed to development environment