### PR TITLE
update oauth2-proxy image to 7.8.1 in dev and playground

### DIFF
--- a/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -68,7 +68,7 @@ spec:
                     memory: 3000M
                   requests:
                     memory: 700M
-            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1 # https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.8.1 # https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               enforce:
                 level: baseline

--- a/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -63,7 +63,7 @@ spec:
                 limitrange:
                   default:
                     memory: 500M
-            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
+            oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.8.1 #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags
             podSecurityStandard: # Ref https://kubernetes.io/docs/concepts/security/pod-security-standards/
               enforce:
                 level: baseline


### PR DESCRIPTION
v7.8.x is a requirment for federated credentials, ref https://github.com/equinor/radix/issues/359