### PR TITLE
defined groupid to grant user access to Radix platform

### DIFF
--- a/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -83,6 +83,8 @@ spec:
             seccompProfile:
               installer:
                 image: ${RADIX_SECCOMP_PROFILE_INSTALLER_IMAGE}
+            radixGroups:
+              user: 64b28659-4fe4-4222-8497-85dd7e43e25b
       target:
         kind: HelmRelease
         name: radix-operator

--- a/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/development/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -84,6 +84,8 @@ spec:
             seccompProfile:
               installer:
                 image: ${RADIX_SECCOMP_PROFILE_INSTALLER_IMAGE}
+            radixGroups:
+              user: 64b28659-4fe4-4222-8497-85dd7e43e25b
       target:
         kind: HelmRelease
         name: radix-operator

--- a/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -79,6 +79,8 @@ spec:
             seccompProfile:
               installer:
                 image: ${RADIX_SECCOMP_PROFILE_INSTALLER_IMAGE}
+            radixGroups:
+              user: 4b8ec60e-714c-4a9d-8e0a-3e4cfb3c3d31
       target:
         kind: HelmRelease
         name: radix-operator

--- a/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
+++ b/clusters/production/overlay/radix-platform/radix-operator/radix-operator.yaml
@@ -83,6 +83,8 @@ spec:
             seccompProfile:
               installer:
                 image: ${RADIX_SECCOMP_PROFILE_INSTALLER_IMAGE}
+            radixGroups:
+              user: 64b28659-4fe4-4222-8497-85dd7e43e25b
       target:
         kind: HelmRelease
         name: radix-operator


### PR DESCRIPTION
Currently, the groupid for userr access to the platform is hardcoded in the radix-operator chart (https://github.com/equinor/radix-operator/blob/9ff7d69e4ec610a22ed2e68d084650edcc00cfb8/charts/radix-operator/values.yaml#L159-L162)

The chart also contains hardcoded differentiation between playground cluster and other clusters.
We will remove this hardcoding from the chart, define radixGroups.user to be requiredm, but without a default value

We therefore need to set the correct groupid for radixGroups.user before we move on to fixing the chart.
