### PR TITLE
define group that cicd canary will use for impersonation

### DIFF
--- a/clusters/c2-production/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
+++ b/clusters/c2-production/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
@@ -33,6 +33,8 @@ spec:
             radixApiPrefix: server-radix-api-prod
             radixWebhookPrefix: webhook-radix-github-webhook-prod
             clusterFqdn: ${clusterName}.${dnsZone}
+            radixGroups:
+              user: 64b28659-4fe4-4222-8497-85dd7e43e25b
       target:
         kind: HelmRelease
         name: radix-cicd-canary

--- a/clusters/development/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
+++ b/clusters/development/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
@@ -33,6 +33,8 @@ spec:
             radixApiPrefix: server-radix-api-qa
             radixWebhookPrefix: webhook-radix-github-webhook-qa
             clusterFqdn: ${clusterName}.${dnsZone}
+            radixGroups:
+              user: 64b28659-4fe4-4222-8497-85dd7e43e25b
       target:
         kind: HelmRelease
         name: radix-cicd-canary

--- a/clusters/playground/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
@@ -33,6 +33,8 @@ spec:
             radixApiPrefix: server-radix-api-prod
             radixWebhookPrefix: webhook-radix-github-webhook-prod
             clusterFqdn: ${clusterName}.${dnsZone}
+            radixGroups:
+              user: 4b8ec60e-714c-4a9d-8e0a-3e4cfb3c3d31
       target:
         kind: HelmRelease
         name: radix-cicd-canary

--- a/clusters/production/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
+++ b/clusters/production/overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
@@ -33,6 +33,8 @@ spec:
             radixApiPrefix: server-radix-api-prod
             radixWebhookPrefix: webhook-radix-github-webhook-prod
             clusterFqdn: ${clusterName}.${dnsZone}
+            radixGroups:
+              user: 64b28659-4fe4-4222-8497-85dd7e43e25b
       target:
         kind: HelmRelease
         name: radix-cicd-canary


### PR DESCRIPTION
Define the group that Radix CICD will use when impersonating the Radix platform user group

Prerequisite for https://github.com/equinor/radix-cicd-canary/pull/212