### PR TITLE
Enable blobfuse2 for blob csi driver

### DIFF
--- a/components/third-party/blob-csi-driver/chart/helmRelease.yaml
+++ b/components/third-party/blob-csi-driver/chart/helmRelease.yaml
@@ -45,5 +45,4 @@ spec:
     priorityClassName: radix-component-priority
     node:
       enableBlobfuseProxy: true
-      blobfuseProxy:
-        installBlobfuse2: false
+

--- a/components/third-party/blob-csi-driver/chart/helmRelease.yaml
+++ b/components/third-party/blob-csi-driver/chart/helmRelease.yaml
@@ -43,6 +43,3 @@ spec:
         cpu: 100m
         memory: 150Mi
     priorityClassName: radix-component-priority
-    node:
-      enableBlobfuseProxy: true
-


### PR DESCRIPTION
Removed node section:
- Default value for enableBlobfuseProxy is true, so no need to set it again
- installBlobfuse2 should not be false (the default is true when omitted). This will skip installation of blobfuse2 and fuse3 driver.

Ref task: https://github.com/equinor/radix/issues/348