### PR TITLE
Increase cpu request and limit for grafana in dev

### DIFF
--- a/clusters/development/overlay/third-party/grafana/patches.yaml
+++ b/clusters/development/overlay/third-party/grafana/patches.yaml
@@ -14,8 +14,8 @@ spec:
           path: /spec/values/resources
           value: 
             limits:
-              cpu: 1m
+              cpu: 100m
               memory: 256Mi
             requests:
-              cpu: 1m
+              cpu: 20m
               memory: 128Mi


### PR DESCRIPTION
It was set to 1m, which made everything reeeeeally slow