### PR TITLE
fix: grafana oomkilled

### DIFF
--- a/clusters/monitoring/overlay/third-party/grafana/patches.yaml
+++ b/clusters/monitoring/overlay/third-party/grafana/patches.yaml
@@ -33,9 +33,9 @@ spec:
             env:
               GF_AZURE_WORKLOAD_IDENTITY_ENABLED: "true"
             resources:
-              limits:
+               limits:
+                 cpu: 128m
+                 memory: 1Gi
+              requests:
                 cpu: 64m
                 memory: 512Mi
-              requests:
-                cpu: 32m
-                memory: 256Mi


### PR DESCRIPTION
Grafana in Ext-Mon is being OOMKilled, Doubling the resources allowance for now