### PR TITLE
increase mem and cpu for kube-state-metrics in playground

### DIFF
--- a/clusters/playground/overlay/third-party/kube-prometheus-stack/patches.yaml
+++ b/clusters/playground/overlay/third-party/kube-prometheus-stack/patches.yaml
@@ -52,8 +52,8 @@ spec:
             kube-state-metrics:
               resources:
                 limits:
-                  cpu: 10m
-                  memory: 256Mi
+                  cpu: 50m
+                  memory: 800Mi
                 requests:
-                  cpu: 5m
-                  memory: 128Mi
+                  cpu: 10m
+                  memory: 400Mi


### PR DESCRIPTION
kube-state-metrics is OOM killed. Actual mem utilization is ~350M.