### PR TITLE
fix: sourceversion for blob csi driver from artifacthub

### DIFF
--- a/clusters/c2-production/postBuild.yaml
+++ b/clusters/c2-production/postBuild.yaml
@@ -10,7 +10,7 @@ spec:
       ACTIVE_CLUSTER: c2-11
       AZ_RESOURCE_DNS: c2.radix.equinor.com
       AZ_SUBSCRIPTION_ID: ded7ca41-37c8-4085-862f-b11d21ab341a
-      BLOB_CSI_DRIVER: v1.26.0 # https://github.com/kubernetes-sigs/blob-csi-driver/releases
+      BLOB_CSI_DRIVER: v1.26.0 # https://artifacthub.io/packages/helm/blob-csi-driver/blob-csi-driver
       CERT_MANAGER_CLUSTER_ISSUER_DNZ_ZONE_MI: abdbd354-57e3-4bac-9fc6-b99ef03c0905 # MI radix-id-certmanager-c2
       CERT_MANAGER_DNZ_ZONE_RESOURCE_GROUP: common-c2
       CERT_MANAGER_VERSION: 1.17.1 # https://artifacthub.io/packages/helm/cert-manager/cert-manager

--- a/clusters/playground/postBuild.yaml
+++ b/clusters/playground/postBuild.yaml
@@ -10,7 +10,7 @@ spec:
       ACTIVE_CLUSTER: playground-29
       AZ_RESOURCE_DNS: playground.radix.equinor.com
       AZ_SUBSCRIPTION_ID: 16ede44b-1f74-40a5-b428-46cca9a5741b
-      BLOB_CSI_DRIVER: v1.26.0 # https://github.com/kubernetes-sigs/blob-csi-driver/releases
+      BLOB_CSI_DRIVER: v1.26.0 # https://artifacthub.io/packages/helm/blob-csi-driver/blob-csi-driver
       CERT_MANAGER_CLUSTER_ISSUER_DNZ_ZONE_MI: fb932ba4-56e6-468d-9e75-4389507a3fde # MI radix-id-certmanager-playground
       CERT_MANAGER_DNZ_ZONE_RESOURCE_GROUP: common-playground
       CERT_MANAGER_VERSION: 1.17.1 # https://artifacthub.io/packages/helm/cert-manager/cert-manager

--- a/clusters/production/postBuild.yaml
+++ b/clusters/production/postBuild.yaml
@@ -10,7 +10,7 @@ spec:
       ACTIVE_CLUSTER: eu-18
       AZ_RESOURCE_DNS: radix.equinor.com
       AZ_SUBSCRIPTION_ID: ded7ca41-37c8-4085-862f-b11d21ab341a
-      BLOB_CSI_DRIVER: v1.26.0 # https://github.com/kubernetes-sigs/blob-csi-driver/releases
+      BLOB_CSI_DRIVER: v1.26.0 # https://artifacthub.io/packages/helm/blob-csi-driver/blob-csi-driver
       CERT_MANAGER_CLUSTER_ISSUER_DNZ_ZONE_MI: 42416e89-eff0-40db-9d42-c1fc5e6fff33 # MI radix-id-certmanager-platform
       CERT_MANAGER_DNZ_ZONE_RESOURCE_GROUP: common-platform
       CERT_MANAGER_VERSION: 1.17.1 # https://artifacthub.io/packages/helm/cert-manager/cert-manager


### PR DESCRIPTION
BLOB CSI Driver doesnt sync chart releases with github releases, so check artifacthub instead