### PR TITLE
fix: set strict-validate-path-type to false to prevent errors in cert-manager

### DIFF
--- a/clusters/c2-production/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/c2-production/overlay/third-party/ingress-nginx/patches.yaml
@@ -29,9 +29,6 @@ spec:
               service:
                 annotations:
                   service.beta.kubernetes.io/azure-load-balancer-resource-group: clusters-c2
-              config:
-                max-worker-connections: "5000"
-                worker-processes: "1"
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:

--- a/clusters/development/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/development/overlay/third-party/ingress-nginx/patches.yaml
@@ -28,10 +28,6 @@ spec:
               service:
                 annotations:
                   service.beta.kubernetes.io/azure-load-balancer-resource-group: clusters-dev
-              config:
-                proxy-buffering: "on"
-                max-worker-connections: "5000"
-                worker-processes: "1"
               affinity:
                 nodeAffinity:
                   requiredDuringSchedulingIgnoredDuringExecution:

--- a/clusters/playground/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/playground/overlay/third-party/ingress-nginx/patches.yaml
@@ -29,11 +29,6 @@ spec:
               service:
                 annotations:
                   service.beta.kubernetes.io/azure-load-balancer-resource-group: clusters-playground
-              config:
-                proxy-buffering: "on"
-                max-worker-connections: "5000"
-                worker-processes: "1"
-
       target:
         kind: HelmRelease
         name: ingress-nginx

--- a/clusters/production/overlay/third-party/ingress-nginx/patches.yaml
+++ b/clusters/production/overlay/third-party/ingress-nginx/patches.yaml
@@ -29,10 +29,6 @@ spec:
               service:
                 annotations:
                   service.beta.kubernetes.io/azure-load-balancer-resource-group: clusters-platform
-              config:
-                proxy-buffering: "on"
-                max-worker-connections: "5000"
-                worker-processes: "1"
               affinity:
                 nodeAffinity:
                   requiredDuringSchedulingIgnoredDuringExecution:

--- a/components/third-party/ingress-nginx/chart/helmRelease.yaml
+++ b/components/third-party/ingress-nginx/chart/helmRelease.yaml
@@ -45,10 +45,14 @@ spec:
       ingressClassByName: true
       watchIngressWithoutClass: true
       config:
+        worker-processes: "1"
+        max-worker-connections: "5000"
+        worker-shutdown-timeout: "3600s"
         annotations-risk-level: "High"
+        strict-validate-path-type: "false"
         proxy-buffer-size: "32k" # See https://stackoverflow.com/a/40306737 for a great explanation
         proxy-body-size: "100m"
-        worker-shutdown-timeout: "3600s"
+        proxy-buffering: "on"
         large-client-header-buffers: "4 32k"
         custom-http-errors: "503"
       extraArgs:


### PR DESCRIPTION
- Setting this option to false resolves cert-manager isseu described here: https://deploy-preview-1720--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.18/#major-themes
- Moved common nginx cluster specific configurations to component