### PR TITLE
fix: rollback blob-csi-driver to previous version

### DIFF
--- a/clusters/production/postBuild.yaml
+++ b/clusters/production/postBuild.yaml
@@ -10,7 +10,7 @@ spec:
       ACTIVE_CLUSTER: eu-18
       AZ_RESOURCE_DNS: radix.equinor.com
       AZ_SUBSCRIPTION_ID: ded7ca41-37c8-4085-862f-b11d21ab341a
-      BLOB_CSI_DRIVER: 1.27.0 # https://artifacthub.io/packages/helm/blob-csi-driver/blob-csi-driver
+      BLOB_CSI_DRIVER: 1.26.3 # https://artifacthub.io/packages/helm/blob-csi-driver/blob-csi-driver
       CERT_MANAGER_CLUSTER_ISSUER_DNZ_ZONE_MI: 42416e89-eff0-40db-9d42-c1fc5e6fff33 # MI radix-id-certmanager-platform
       CERT_MANAGER_DNZ_ZONE_RESOURCE_GROUP: common-platform
       CERT_MANAGER_VERSION: 1.18.2 # https://artifacthub.io/packages/helm/cert-manager/cert-manager


### PR DESCRIPTION
Volume mounts for app tp-vnext stopped working the same day we upgraded to 1.27.0
Downgrading to 1.26.3 to see if that fixes the issue. If it does, then we need to investigate why 1.27.0 fails to correctly mount their storage account