### PR TITLE
fix: remove clusterActiveEgressIps from HelmRelease values

### DIFF
--- a/components/radix-platform/radix-operator/helmRelease.yaml
+++ b/components/radix-platform/radix-operator/helmRelease.yaml
@@ -17,7 +17,6 @@ spec:
     appAliasBaseURL: ${appAliasBaseURL} # set in configmap flux-system/radix-flux-config
     prometheusName: ${prometheusName} # set in configmap flux-system/radix-flux-config
     clusterType: ${clusterType} # set in configmap flux-system/radix-flux-config
-    clusterActiveEgressIps: ${activeClusterIPs} # set in configmap flux-system/radix-flux-config
     clusterName: ${clusterName} # set in configmap flux-system/radix-flux-config
 
     subscriptionId: ${AZ_SUBSCRIPTION_ID}


### PR DESCRIPTION
Remove `clusterActiveEgressIps` from radix-operator HelmRelease. This helm value was removed from radix-operator in [this PR](https://github.com/equinor/radix-operator/pull/1481) and should therefore be removed from flux