### PR TITLE
chore(deps): update OAUTH2PROXY_TAG to v7.12.0 in postBuild.yaml for production and c2-production clusters

### DIFF
--- a/clusters/c2-production/postBuild.yaml
+++ b/clusters/c2-production/postBuild.yaml
@@ -31,7 +31,7 @@ spec:
       KUBE_PROMETHEUS_STACK: 76.4.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
       KUBERNETES_REPLICATOR: v2.12.0 # https://github.com/mittwald/kubernetes-replicator
       NGINX_VERSION: 4.13.3 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
-      OAUTH2PROXY_TAG: "v7.9.0"
+      OAUTH2PROXY_TAG: "v7.12.0"
       OAUTH2REDIS_TAG: 8.2.2-alpine3.22
       RADIX_ACR_CLEANUP_CHART_VERSION: 1.4.0 # {"$imagepolicy": "flux-system:radix-acr-cleanup-chart:tag"}
       radix_acr_repo_url: radixc2prod.azurecr.io

--- a/clusters/production/postBuild.yaml
+++ b/clusters/production/postBuild.yaml
@@ -31,7 +31,7 @@ spec:
       KUBE_PROMETHEUS_STACK: 76.4.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
       KUBERNETES_REPLICATOR: v2.12.0 # https://github.com/mittwald/kubernetes-replicator
       NGINX_VERSION: 4.13.3 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
-      OAUTH2PROXY_TAG: "v7.9.0"
+      OAUTH2PROXY_TAG: "v7.12.0"
       OAUTH2REDIS_TAG: 8.2.2-alpine3.22
       RADIX_ACR_CLEANUP_CHART_VERSION: 1.4.0 # {"$imagepolicy": "flux-system:radix-acr-cleanup-chart:tag"}
       radix_acr_repo_url: radixprod.azurecr.io


### PR DESCRIPTION
This pull request updates the `OAUTH2PROXY_TAG` version in the post-build configuration files for both the `c2-production` and `production` Kubernetes clusters. The change ensures that both environments use the latest stable release of OAuth2 Proxy.

This fixes a critical vulnerability: https://avd.aquasec.com/nvd/2025/cve-2025-54576/

Dependency version updates:

* Upgraded `OAUTH2PROXY_TAG` from `"v7.9.0"` to `"v7.12.0"` in `clusters/c2-production/postBuild.yaml` to use the latest OAuth2 Proxy version.
* Upgraded `OAUTH2PROXY_TAG` from `"v7.9.0"` to `"v7.12.0"` in `clusters/production/postBuild.yaml` to use the latest OAuth2 Proxy version.