### PR TITLE
fix: update Istio version to 1.28.1

### DIFF
--- a/clusters/development/postBuild.yaml
+++ b/clusters/development/postBuild.yaml
@@ -28,7 +28,7 @@ spec:
       GRAFANA_LOKI: 2.10.3 # https://artifacthub.io/packages/helm/grafana/loki-stack
       GRAFANA_VERSION: 10.1.4 # https://artifacthub.io/packages/helm/grafana/grafana
       GRAFANA_WI_CLIENT_ID: 1150acff-2bc7-47df-a1b2-b45dbeaaf58a
-      ISTIO_VERSION: 1.27.1 # https://artifacthub.io/packages/helm/istio-official/istiod
+      ISTIO_VERSION: 1.28.1 # https://artifacthub.io/packages/helm/istio-official/istiod
       KEDA_VERSION: 2.18.1 # https://artifacthub.io/packages/helm/kedacore/keda
       KUBE_PROMETHEUS_STACK: 79.5.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
       KUBERNETES_REPLICATOR: v2.12.1 # https://github.com/mittwald/kubernetes-replicator


### PR DESCRIPTION
Version [1.28.1](https://istio.io/latest/news/releases/1.28.x/announcing-1.28.1/) fixes the [XListenerSet tls issue](https://github.com/istio/istio/issues/58019).