### PR TITLE
refactor: remove audit and warn security standards from HelmRelease configuration

### DIFF
--- a/components/radix-platform/radix-operator/helmRelease.yaml
+++ b/components/radix-platform/radix-operator/helmRelease.yaml
@@ -130,9 +130,3 @@ spec:
       enforce:
         level: baseline
         version: v1.23
-      audit:
-        level: restricted
-        version: v1.23
-      warn:
-        level: restricted
-        version: v1.23


### PR DESCRIPTION
Remove audit and warn levels to get rid of noisy "warn" log messages in radix-operator