### PR TITLE
Upgrade KEDA version to 2.18.3 in postBuild.yaml for all clusters

### DIFF
--- a/clusters/c2-production/postBuild.yaml
+++ b/clusters/c2-production/postBuild.yaml
@@ -27,7 +27,7 @@ spec:
       GRAFANA_DB_USERNAME: radix-id-grafana-admin-c2
       GRAFANA_VERSION: 9.3.2 # https://artifacthub.io/packages/helm/grafana/grafana
       GRAFANA_WI_CLIENT_ID: fa6ac394-78ec-4710-9923-77b772f5de74
-      KEDA_VERSION: 2.17.2 # https://artifacthub.io/packages/helm/kedacore/keda
+      KEDA_VERSION: 2.18.3 # https://artifacthub.io/packages/helm/kedacore/keda
       KUBE_PROMETHEUS_STACK: 76.4.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
       KUBERNETES_REPLICATOR: v2.12.0 # https://github.com/mittwald/kubernetes-replicator
       NGINX_VERSION: 4.13.3 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx

--- a/clusters/c3/postBuild.yaml
+++ b/clusters/c3/postBuild.yaml
@@ -27,7 +27,7 @@ spec:
       GRAFANA_DB_USERNAME: radix-id-grafana-admin-c3
       GRAFANA_VERSION: 9.3.2 # https://artifacthub.io/packages/helm/grafana/grafana
       GRAFANA_WI_CLIENT_ID: 3cd52da4-a716-414c-9275-96e8034ae0bd
-      KEDA_VERSION: 2.17.2 # https://artifacthub.io/packages/helm/kedacore/keda
+      KEDA_VERSION: 2.18.3 # https://artifacthub.io/packages/helm/kedacore/keda
       KUBE_PROMETHEUS_STACK: 76.4.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
       KUBERNETES_REPLICATOR: v2.12.0 # https://github.com/mittwald/kubernetes-replicator
       NGINX_VERSION: 4.13.3 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx

--- a/clusters/playground/postBuild.yaml
+++ b/clusters/playground/postBuild.yaml
@@ -27,7 +27,7 @@ spec:
       GRAFANA_DB_USERNAME: radix-id-grafana-admin-playground
       GRAFANA_VERSION: 9.3.2 # https://artifacthub.io/packages/helm/grafana/grafana
       GRAFANA_WI_CLIENT_ID: f8597620-379a-40ac-9f1d-1fed7da71204
-      KEDA_VERSION: 2.17.2 # https://artifacthub.io/packages/helm/kedacore/keda
+      KEDA_VERSION: 2.18.3 # https://artifacthub.io/packages/helm/kedacore/keda
       KUBE_PROMETHEUS_STACK: 76.4.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
       KUBERNETES_REPLICATOR: v2.12.0 # https://github.com/mittwald/kubernetes-replicator
       NGINX_VERSION: 4.13.3 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx

--- a/clusters/production/postBuild.yaml
+++ b/clusters/production/postBuild.yaml
@@ -27,7 +27,7 @@ spec:
       GRAFANA_DB_USERNAME: radix-id-grafana-admin-platform
       GRAFANA_VERSION: 9.3.2 # https://artifacthub.io/packages/helm/grafana/grafana
       GRAFANA_WI_CLIENT_ID: d7c9d6c1-1688-4016-befe-7506a16a459c
-      KEDA_VERSION: 2.17.2 # https://artifacthub.io/packages/helm/kedacore/keda
+      KEDA_VERSION: 2.18.3 # https://artifacthub.io/packages/helm/kedacore/keda
       KUBE_PROMETHEUS_STACK: 76.4.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
       KUBERNETES_REPLICATOR: v2.12.0 # https://github.com/mittwald/kubernetes-replicator
       NGINX_VERSION: 4.13.3 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx


### PR DESCRIPTION
This pull request updates the KEDA Helm chart version across multiple cluster configuration files. The KEDA version is bumped from 2.17.2 to 2.18.3 to ensure all environments use the latest features and bug fixes.

Cluster configuration updates:

* Bumped `KEDA_VERSION` from 2.17.2 to 2.18.3 in the following files:
  - `clusters/production/postBuild.yaml`
  - `clusters/c2-production/postBuild.yaml`
  - `clusters/c3/postBuild.yaml`
  - `clusters/playground/postBuild.yaml`