### PR TITLE
chore: Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-version.yaml
+++ b/.github/workflows/check-version.yaml
@@ -30,6 +30,9 @@ jobs:
   check-version:
     name: Check for new versions
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: checkout


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/radix-flux/security/code-scanning/3](https://github.com/equinor/radix-flux/security/code-scanning/3)

In general, to fix this kind of issue, you explicitly set `permissions` for the `GITHUB_TOKEN` either at the workflow root (applies to all jobs) or for individual jobs. Those permissions should be limited to just what the workflow needs (e.g., `contents: read` for checking out code, plus `contents: write` and/or `pull-requests: write` if the workflow creates branches and PRs).

For this specific workflow, the `Create PR` step strongly suggests that the scripts it runs will push branches and open pull requests using `GITHUB_TOKEN`, which requires `contents: write` (for pushing commits/branches) and `pull-requests: write` (for creating/updating PRs). At minimum, the workflow also requires `contents: read` for `actions/checkout`. The simplest, least-disruptive fix is to add a `permissions` block for the `check-version` job specifying `contents: write` and `pull-requests: write`. This keeps existing behavior while making the required permissions explicit and not granting unrelated scopes like `issues` or `actions`. We only need to modify `.github/workflows/check-version.yaml`, adding the block under `jobs.check-version:` and leaving the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
