### PR TITLE
chore(deps): upgrade external-secrets helm chart from 1.2.0 to 1.2.1

### DIFF
--- a/clusters/development/postBuild.yaml
+++ b/clusters/development/postBuild.yaml
@@ -16,9 +16,9 @@ spec:
       CERT_MANAGER_VERSION: 1.19.2 # https://artifacthub.io/packages/helm/cert-manager/cert-manager
       COST_ALLOCATION_SQL_CLIENT_ID: 89cd29bf-1e13-421c-a383-2492c1150b4c
       COST_ALLOCATION_SQL_SERVER: sql-radix-cost-allocation-dev.database.windows.net
-      EXTERNAL_SECRET_MI_CLIENT_ID: b3f4e788-84bd-458e-9f49-d62f1c325a8d
+      EXTERNAL_SECRET_MI_CLIENT_ID: b3f4e788-84bd-458e-9f49-d62f1c325a8d # gitleaks:allow
       EXTERNAL_SECRET_URL: https://radix-keyv-dev.vault.azure.net/
-      EXTERNAL_SECRETS: 1.2.0 # https://artifacthub.io/packages/helm/external-secrets-operator/external-secrets
+      EXTERNAL_SECRETS: 1.2.1 # https://artifacthub.io/packages/helm/external-secrets-operator/external-secrets
       EXTMON_CLUSTER_ISSUER: "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/a2d93ba1-cbde-4408-8979-c100cce7b448/"
       FLUX_CONFIG_PATH: ./clusters/development
       GIT_CLONE_TAG: "2.45.2"


### PR DESCRIPTION
Issue: https://github.com/equinor/radix-flux/issues/3117