### PR TITLE
chore: change external secret refresh interval from 1h to 5m

### DIFF
--- a/components/flux/externalsecrets/secrets/secret.yaml
+++ b/components/flux/externalsecrets/secrets/secret.yaml
@@ -37,7 +37,7 @@ spec:
   secretStoreRef:
     name: radix-keyvault
     kind: ClusterSecretStore
-  refreshInterval: "1h"
+  refreshInterval: 5m
   target:
     template:
 
@@ -96,7 +96,7 @@ spec:
   secretStoreRef:
     name: radix-keyvault
     kind: ClusterSecretStore
-  refreshInterval: "1h"
+  refreshInterval: 5m
   target:
     template:
       metadata:
@@ -118,7 +118,7 @@ spec:
   secretStoreRef:
     name: radix-keyvault
     kind: ClusterSecretStore
-  refreshInterval: "1h"
+  refreshInterval: 5m
   target:
     name: radix-docker
     creationPolicy: Owner
@@ -155,7 +155,7 @@ spec:
   secretStoreRef:
     name: radix-keyvault
     kind: ClusterSecretStore
-  refreshInterval: "1h"
+  refreshInterval: 5m
   target:
     name: radix-docker
     creationPolicy: Owner
@@ -193,7 +193,7 @@ spec:
   secretStoreRef:
     name: radix-keyvault
     kind: ClusterSecretStore
-  refreshInterval: "1h"
+  refreshInterval: 5m
   target:
     template:
       metadata:

--- a/components/third-party/cert-manager-issuers/digicert/externalaccount/resources/secret.yaml
+++ b/components/third-party/cert-manager-issuers/digicert/externalaccount/resources/secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: digicert-clusterissuer-flux-values
   namespace: flux-system
 spec:
-  refreshInterval: "1h"
+  refreshInterval: 5m
   secretStoreRef:
     name: radix-keyvault
     kind: ClusterSecretStore

--- a/components/third-party/grafana/chart/secret.yaml
+++ b/components/third-party/grafana/chart/secret.yaml
@@ -7,7 +7,7 @@ spec:
   secretStoreRef:
     name: radix-keyvault
     kind: ClusterSecretStore
-  refreshInterval: "1h"
+  refreshInterval: 5m
   target:
     name: grafana-secrets
     creationPolicy: Owner

--- a/components/third-party/velero/chart/secret.yaml
+++ b/components/third-party/velero/chart/secret.yaml
@@ -7,7 +7,7 @@ spec:
   secretStoreRef:
     name: radix-keyvault
     kind: ClusterSecretStore
-  refreshInterval: "1h"
+  refreshInterval: 5m
   target:
     template:
       metadata:


### PR DESCRIPTION
This pull request reduces the `refreshInterval` for several ExternalSecret resources from 1 hour to 5 minutes. This change ensures that secrets are synchronized more frequently from the external secret store, improving the responsiveness to updates in the backing secret store.