### PR TITLE
fix: Enable Gateway API in cert-manager configuration

### DIFF
--- a/components/third-party/cert-manager/chart/helmRelease.yaml
+++ b/components/third-party/cert-manager/chart/helmRelease.yaml
@@ -19,6 +19,10 @@ spec:
       retries: 3
   values:
     # resources: xx # Set by flux patch
+    config: # https://cert-manager.io/docs/installation/configuring-components/#configuration-file
+      apiVersion: controller.config.cert-manager.io/v1alpha1
+      kind: ControllerConfiguration
+      enableGatewayAPI: true
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This pull request introduces a configuration update to the cert-manager Helm release, enabling Gateway API support through the controller configuration.

Configuration update:

* Added a `config` section to the Helm values, specifying a `ControllerConfiguration` with `enableGatewayAPI: true` to support Gateway API integration.