### PR TITLE
fix: replace remove updated field to changed

### DIFF
--- a/components/flux/image-update-automation/imageUpdateAutomation.yaml
+++ b/components/flux/image-update-automation/imageUpdateAutomation.yaml
@@ -35,7 +35,7 @@ spec:
         {{- range $_, $change := $changes }}
             - {{ $change.OldValue }} -> {{ $change.NewValue }}
         {{ end -}}
-        {{ end -}}  
+        {{ end -}}
     push:
       branch: flux-image-updates
   update:


### PR DESCRIPTION
I replaced out message template with the example from flux docs

https://fluxcd.io/flux/components/image/imageupdateautomations/#message-template

basically replacing Updated with Changed

based on the logs from Image Update Automation tool:

```json
{
  "level": "error",
  "ts": "2026-01-30T05:24:59.094Z",
  "msg": "template uses removed '.Updated' field. Please use '.Changed' instead. See: https://fluxcd.io/flux/components/image/imageupdateautomations/#message-template",
  "controller": "imageupdateautomation",
  "controllerGroup": "image.toolkit.fluxcd.io",
  "controllerKind": "ImageUpdateAutomation",
  "ImageUpdateAutomation":
    { "name": "radix-acr-auto-update", "namespace": "flux-system" },
  "namespace": "flux-system",
  "name": "radix-acr-auto-update",
  "reconcileID": "7344e39a-1ecf-451b-8dec-eadb5d03ab90",
  "error": "RemovedTemplateField",
}

```