### PR TITLE
chore: Update Kube Prometheus Stack version to 81.3.2 for development

### DIFF
--- a/clusters/development/postBuild.yaml
+++ b/clusters/development/postBuild.yaml
@@ -29,7 +29,7 @@ spec:
       GRAFANA_VERSION: 10.4.0 # https://artifacthub.io/packages/helm/grafana/grafana
       GRAFANA_WI_CLIENT_ID: 1150acff-2bc7-47df-a1b2-b45dbeaaf58a # gitleaks:allow
       KEDA_VERSION: 2.18.3 # https://artifacthub.io/packages/helm/kedacore/keda
-      KUBE_PROMETHEUS_STACK: 80.14.4 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack # newer version fails. ref: https://github.com/equinor/radix-platform/issues/1849
+      KUBE_PROMETHEUS_STACK: 81.3.2 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack # newer version fails. ref: https://github.com/equinor/radix-platform/issues/1849
       KUBERNETES_REPLICATOR: v2.12.2 # https://github.com/mittwald/kubernetes-replicator
       NGINX_VERSION: 4.14.1 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
       OAUTH2PROXY_TAG: "v7.12.0" #https://quay.io/repository/oauth2-proxy/oauth2-proxy?tag=latest&tab=tags


### PR DESCRIPTION
Issue described in https://github.com/equinor/radix-platform/issues/1849 is resolved in version 81.3.2