### PR TITLE
chore: configure workflow permissions for test-kustomization-build

### DIFF
--- a/.github/workflows/test-kustomization-build.yaml
+++ b/.github/workflows/test-kustomization-build.yaml
@@ -1,4 +1,6 @@
 name: radix-flux-pr
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/radix-flux/security/code-scanning/2](https://github.com/equinor/radix-flux/security/code-scanning/2)

To fix the problem, explicitly define minimal `GITHUB_TOKEN` permissions for this workflow or for the specific job. Since the job only needs to read repository contents (via `actions/checkout`) and run local commands (`kustomize build`), it can safely operate with `contents: read` only.

The best fix without changing existing functionality is to add a `permissions:` block at the workflow root so it applies to all jobs (currently just `kustomize-build`). Place it just after the `name:` (or after the `on:`) and set `contents: read`. No other permissions appear necessary for the given steps, and no additional imports or methods are required because this is a YAML workflow configuration change only.

Concretely, in `.github/workflows/test-kustomization-build.yaml`, add:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., between `name: radix-flux-pr` and `on:`). This documents and enforces the least-privilege access for the `GITHUB_TOKEN` used in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
