### PR TITLE
feat: Update viewGroup for Entra Groups in RBAC configurations

### DIFF
--- a/clusters/development/overlay/radix-platform/radix-platform/rbac.yaml
+++ b/clusters/development/overlay/radix-platform/radix-platform/rbac.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   postBuild:
     substitute:
-      viewGroup: a5dfa635-dc00-4a28-9ad9-9e7f1e56919d # Entra Group "Radix Platform Developers"
+      viewGroup: 0095272d-cb0a-4284-b1b5-86787b692627 # Entra Group "AZAPPL S941 - Contributor"
       editGroup: 47ceeaf1-4794-4291-bf1c-68f45788b66f # Entra Group "AZ PIM OMNIA RADIX Cluster Edit - dev"
       adminGroup: bed2b667-ceec-4377-83f7-46888ed23887 # Entra Group "AZ PIM OMNIA RADIX Cluster Admin - dev"

--- a/clusters/playground/overlay/radix-platform/radix-platform/rbac.yaml
+++ b/clusters/playground/overlay/radix-platform/radix-platform/rbac.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   postBuild:
     substitute:
-      viewGroup: a5dfa635-dc00-4a28-9ad9-9e7f1e56919d # Entra Group "Radix Platform Developers"
+      viewGroup: 0095272d-cb0a-4284-b1b5-86787b692627 # Entra Group "AZAPPL S941 - Contributor"
       editGroup: 47ceeaf1-4794-4291-bf1c-68f45788b66f # Entra Group "AZ PIM OMNIA RADIX Cluster Edit - dev"
       adminGroup: bed2b667-ceec-4377-83f7-46888ed23887 # Entra Group "AZ PIM OMNIA RADIX Cluster Admin - dev"

--- a/components/radix-platform/radix-platform/rbac.yaml
+++ b/components/radix-platform/radix-platform/rbac.yaml
@@ -14,6 +14,6 @@ spec:
   timeout: 2m
   postBuild:
     substitute:
-      viewGroup: be5526de-1b7d-4389-b1ab-a36a99ef5cc5 # Entra Group "Radix Platform Operators"
+      viewGroup: 17b94e5c-3174-4efa-9b88-45980b49997b # Entra Group "AZAPPL S940 - Contributor"
       editGroup: fa475c8f-5202-444a-a3f3-734f02938616 # Entra Group "AZ PIM OMNIA RADIX Cluster Edit - prod"
       adminGroup: 0e0d22c6-9f03-48a5-89be-be7b060c8a32 # Entra Group "AZ PIM OMNIA RADIX Cluster Admin - prod"


### PR DESCRIPTION
Change group for default cluster view access to `AZAPPL S941 - Contributor` for dev and plyaground, and `AZAPPL S940 - Contributor` for prod clusters