### PR TITLE
feat: enable http10 support in Istio

### DIFF
--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: 3239-enable-http10-support
+    branch: master
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux


### PR DESCRIPTION
Some applications in Radix still receives request with HTTP/1.0 protocol, so we will enable support for this protocol for a limited time.

I have added a task to disable support for this protocol in the task: https://github.com/equinor/radix-flux/issues/3240