### PR TITLE
fix: set monitor health label on external DNS pod

### DIFF
--- a/components/third-party/external-dns/helmRelease.yaml
+++ b/components/third-party/external-dns/helmRelease.yaml
@@ -55,6 +55,7 @@ spec:
 
     podLabels:
       azure.workload.identity/use: "true"
+      grafana.radix.equinor.com/monitor-health: "true"
 
     extraVolumes:
       - name: azure-config-file


### PR DESCRIPTION
The label ensures that the pods are included in `component status` graph on Radix ext mon dashboard