### PR TITLE
feat: enable external dns for grafana httproute in all clusters

### DIFF
--- a/clusters/development/overlay/third-party/grafana/patches.yaml
+++ b/clusters/development/overlay/third-party/grafana/patches.yaml
@@ -24,11 +24,6 @@ spec:
               requests:
                 cpu: 20m
                 memory: 128Mi
-            route:
-              main:
-                annotations:
-                  external-dns.alpha.kubernetes.io/ttl: "30"
-                  radix.equinor.com/preview-gateway-mode: "true"
             env:
               GF_AUTH_GENERIC_OAUTH_ENABLED: "false"
               GF_AUTH_AZUREAD_ENABLED: "true"

--- a/clusters/playground/overlay/third-party/grafana/patches.yaml
+++ b/clusters/playground/overlay/third-party/grafana/patches.yaml
@@ -24,11 +24,6 @@ spec:
               requests:
                 cpu: 20m
                 memory: 128Mi
-            route:
-              main:
-                annotations:
-                  external-dns.alpha.kubernetes.io/ttl: "30"
-                  radix.equinor.com/preview-gateway-mode: "true"                
             env:
               GF_AUTH_GENERIC_OAUTH_ENABLED: "false"
               GF_AUTH_AZUREAD_ENABLED: "true"

--- a/components/third-party/grafana/chart/helmRelease.yaml
+++ b/components/third-party/grafana/chart/helmRelease.yaml
@@ -65,6 +65,9 @@ spec:
     route:
       main:
         enabled: true
+        annotations:
+          external-dns.alpha.kubernetes.io/ttl: "30"
+          radix.equinor.com/preview-gateway-mode: "true"
         parentRefs:
         - group: gateway.networking.k8s.io
           kind: Gateway


### PR DESCRIPTION
Enable traffic routing through Istio for Grafana in all clusters