### PR TITLE
feat: add reserved DNS aliases for www

### DIFF
--- a/components/radix-platform/radix-operator/helmRelease.yaml
+++ b/components/radix-platform/radix-operator/helmRelease.yaml
@@ -123,6 +123,14 @@ spec:
       requireAdGroups: true
       requireConfigurationItem: true
 
+      reservedAppDNSAliases:
+        api: radix-api
+        canary: radix-canary-golang
+        console: radix-web-console
+        cost-api: radix-cost-allocation-api
+        webhook: radix-github-webhook
+        www: radix-public-site
+
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
www is a reserved alias, so we must whitelist radix-public-site to use it