### PR TITLE
fix(security): disable tekton git resolver

### DIFF
--- a/components/third-party/tekton-v2/v0.79.0/config/tektonconfig.yaml
+++ b/components/third-party/tekton-v2/v0.79.0/config/tektonconfig.yaml
@@ -18,3 +18,4 @@ spec:
     disabled: true
   pipeline:
     running-in-environment-with-injected-sidecars: false
+    enable-git-resolver: false


### PR DESCRIPTION
The git resolver has a critical vulnerability https://github.com/tektoncd/pipeline/security/advisories/GHSA-j5q5-j9gm-2w5c.
This PR disable the git resolver until a new version of tekton operator is available