### PR TITLE
feat: disable external dns record creation in dev clusters

### DIFF
--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: master
+    branch: dev-disable-external-dns-record-creation
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: dev-disable-external-dns-record-creation
+    branch: master
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/infrastructure/third-party/external-dns.yaml
+++ b/clusters/development/infrastructure/third-party/external-dns.yaml
@@ -21,3 +21,16 @@ spec:
       - kind: ConfigMap
         name: radix-flux-config
         optional: false
+  patches:
+    - patch: |
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: external-dns
+          namespace: external-dns
+        spec:
+          values:
+            annotationFilter: "radix.equinor.com/preview-gateway-mode=never"
+      target:
+        kind: HelmRelease
+        name: external-dns


### PR DESCRIPTION
Dev clusters are configured in terraform to use the Istio load balancer IP for aper and wildcard DNS records. This means that all DNS lookups will resolve to the Istio IP. We no longer need external-dns to create Istio specific DNS records