### PR TITLE
feat: disable external dns record creation in playground cluster

### DIFF
--- a/clusters/playground/infrastructure/third-party/external-dns.yaml
+++ b/clusters/playground/infrastructure/third-party/external-dns.yaml
@@ -21,3 +21,16 @@ spec:
       - kind: ConfigMap
         name: radix-flux-config
         optional: false
+  patches:
+    - patch: |
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: external-dns
+          namespace: external-dns
+        spec:
+          values:
+            annotationFilter: "radix.equinor.com/preview-gateway-mode=never"
+      target:
+        kind: HelmRelease
+        name: external-dns


### PR DESCRIPTION
Playground cluster is configured in terraform to use the Istio load balancer IP for apex and wildcard DNS records. This means that all DNS lookups will resolve to the Istio IP. We no longer need external-dns to create Istio specific DNS records