### PR TITLE
feat: increase CPU requests for istio-proxy and add HPA scale down behavior

### DIFF
--- a/clusters/production/infrastructure/third-party/gateway-lb.yaml
+++ b/clusters/production/infrastructure/third-party/gateway-lb.yaml
@@ -34,7 +34,7 @@ spec:
                   - name: istio-proxy
                     resources:
                       requests:
-                        cpu: 100m
+                        cpu: 500m
                         memory: 1Gi
                       limits:
                         cpu: 2000m

--- a/components/third-party/gateway-lb/configmap.yaml
+++ b/components/third-party/gateway-lb/configmap.yaml
@@ -14,7 +14,9 @@ data:
     spec:
       minReplicas: 2
       maxReplicas: 5
-
+      behavior:      
+        scaleDown:
+          stabilizationWindowSeconds: 1800
   podDisruptionBudget: |
     spec:
       minAvailable: 1


### PR DESCRIPTION
- Set Istio cpu request to 500m in platform. Utilization is ~80m which cases HPA to scale up/down to often when cpu request is 100m.
- Set HPA scaledown stabilization 30 minutes to prevent pod "flapping"