### PR TITLE
feat: install istio base helm chart and configure x-forwarded-[host|port]

### DIFF
--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: master
+    branch: 3316-install-istio-base
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: 3316-install-istio-base
+    branch: master
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/infrastructure/third-party/istio-envoyfilter.yaml
+++ b/clusters/development/infrastructure/third-party/istio-envoyfilter.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: istio-envoyfilter
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: "./components/third-party/istio-envoyfilter"
+  dependsOn:
+    - name: istio
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/clusters/development/infrastructure/third-party/kustomization.yaml
+++ b/clusters/development/infrastructure/third-party/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - gateway-api.yaml
   - gateway-lb.yaml
   - istio.yaml
-  # - istio-envoyfilter.yaml
+  - istio-envoyfilter.yaml
   - external-secrets-operator.yaml
   - external-secrets-stores.yaml
   - external-secrets-secrets.yaml

--- a/clusters/development/infrastructure/third-party/kustomization.yaml
+++ b/clusters/development/infrastructure/third-party/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - gateway-api.yaml
   - gateway-lb.yaml
   - istio.yaml
-  - istio-envoyfilter.yaml
+  # - istio-envoyfilter.yaml
   - external-secrets-operator.yaml
   - external-secrets-stores.yaml
   - external-secrets-secrets.yaml

--- a/clusters/development/infrastructure/third-party/kustomization.yaml
+++ b/clusters/development/infrastructure/third-party/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - gateway-api.yaml
   - gateway-lb.yaml
   - istio.yaml
+  - istio-envoyfilter.yaml
   - external-secrets-operator.yaml
   - external-secrets-stores.yaml
   - external-secrets-secrets.yaml

--- a/components/third-party/istio-envoyfilter/envoyfilter-set-x-forwarded-host.yaml
+++ b/components/third-party/istio-envoyfilter/envoyfilter-set-x-forwarded-host.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: set-x-forwarded-host
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.http_connection_manager
+            subFilter:
+              name: envoy.filters.http.router
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: envoy.filters.http.lua
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+          inlineCode: |
+            function envoy_on_request(handle)
+              local headers = handle:headers()
+              local authority = headers:get(":authority")
+              if authority == nil or authority == "" then
+                authority = headers:get("host")
+              end
+
+              if authority ~= nil and authority ~= "" then
+                headers:add("x-forwarded-host", authority)
+              else
+                headers:remove("x-forwarded-host")
+              end
+            end

--- a/components/third-party/istio-envoyfilter/envoyfilter-set-x-forwarded-host.yaml
+++ b/components/third-party/istio-envoyfilter/envoyfilter-set-x-forwarded-host.yaml
@@ -24,12 +24,8 @@ spec:
             function envoy_on_request(handle)
               local headers = handle:headers()
               local authority = headers:get(":authority")
-              if authority == nil or authority == "" then
-                authority = headers:get("host")
-              end
-
               if authority ~= nil and authority ~= "" then
-                headers:add("x-forwarded-host", authority)
+                headers:replace("x-forwarded-host", authority)
               else
                 headers:remove("x-forwarded-host")
               end

--- a/components/third-party/istio-envoyfilter/envoyfilter-set-x-forwarded-host.yaml
+++ b/components/third-party/istio-envoyfilter/envoyfilter-set-x-forwarded-host.yaml
@@ -20,13 +20,14 @@ spec:
         name: envoy.filters.http.lua
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-          inlineCode: |
-            function envoy_on_request(handle)
-              local headers = handle:headers()
-              local authority = headers:get(":authority")
-              if authority ~= nil and authority ~= "" then
-                headers:replace("x-forwarded-host", authority)
-              else
-                headers:remove("x-forwarded-host")
+          defaultSourceCode:
+            inlineString: |
+              function envoy_on_request(handle)
+                local headers = handle:headers()
+                local authority = headers:get(":authority")
+                if authority ~= nil and authority ~= "" then
+                  headers:replace("x-forwarded-host", authority)
+                else
+                  headers:remove("x-forwarded-host")
+                end
               end
-            end

--- a/components/third-party/istio-envoyfilter/kustomization.yaml
+++ b/components/third-party/istio-envoyfilter/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- envoyfilter-set-x-forwarded-host.yaml

--- a/components/third-party/istio/helmRelease-base.yaml
+++ b/components/third-party/istio/helmRelease-base.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: istio-base
+  namespace: istio-system
+spec:
+  releaseName: istio-base
+  chart:
+    spec:
+      chart: base
+      version: ${ISTIO_VERSION} # Set by flux patch
+      sourceRef:
+        kind: HelmRepository
+        name: istio
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace

--- a/components/third-party/istio/helmRelease-istiod.yaml
+++ b/components/third-party/istio/helmRelease-istiod.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: istio-system
 spec:
   releaseName: istiod
+  dependsOn:
+  - name: istio-base
+    namespace: istio-system
   chart:
     spec:
       chart: istiod
@@ -42,6 +45,8 @@ spec:
             disabled: true
           server:
             disabled: true
+          xForwardedPort:
+            enabled: true
     global:
       logAsJson: true
       networkPolicy:

--- a/components/third-party/istio/ingressclass.yaml
+++ b/components/third-party/istio/ingressclass.yaml
@@ -1,6 +1,0 @@
-apiVersion: networking.k8s.io/v1
-kind: IngressClass
-metadata:
-  name: istio
-spec:
-  controller: istio.io/ingress-controller

--- a/components/third-party/istio/kustomization.yaml
+++ b/components/third-party/istio/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 resources:
 - namespace.yaml
 - helmRepo.yaml
-- helmRelease.yaml
-- ingressclass.yaml
+- helmRelease-base.yaml
+- helmRelease-istiod.yaml


### PR DESCRIPTION
- Include istio base (Istio specific CRDs) helm chart in Istio kustomization
- Enable xForwardedPort in Istio to enable Istio to set x-forwarded-port header
- Add EnvoyFilter to enable Istio to control the x-forwarded-host header
- Remove unused IngressClass for Istio