### PR TITLE
Add CVE-2026-31431 monitor resource to kustomization

### DIFF
--- a/components/radix-platform/radix-platform/cve-2026-31431-monitor.yaml
+++ b/components/radix-platform/radix-platform/cve-2026-31431-monitor.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cve-2026-31431-monitor
+  namespace: kube-system
+  labels:
+    app: cve-2026-31431-monitor
+    purpose: security-monitoring
+spec:
+  selector:
+    matchLabels:
+      app: cve-2026-31431-monitor
+  template:
+    metadata:
+      labels:
+        app: cve-2026-31431-monitor
+    spec:
+      hostPID: true
+      priorityClassName: system-node-critical
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: monitor
+          image: mcr.microsoft.com/cbl-mariner/busybox:2.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              MODULES="algif_aead esp4 esp6 rxrpc"
+
+              echo "$(date -Iseconds) INFO: CVE-2026-31431 monitor started. Watching modules: ${MODULES}"
+
+              while true; do
+                for mod in $MODULES; do
+                  if grep -q "^${mod} " /host/proc/modules 2>/dev/null; then
+                    echo "$(date -Iseconds) WARNING: Vulnerable module '${mod}' is loaded"
+                  fi
+                done
+                sleep 10
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: host-proc
+              mountPath: /host/proc
+              readOnly: true
+      volumes:
+        - name: host-proc
+          hostPath:
+            path: /proc
+            type: Directory

--- a/components/radix-platform/radix-platform/kustomization.yaml
+++ b/components/radix-platform/radix-platform/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - rbac/radix-platform-operators-admin.yaml
   - networking/namespace.public-site.yaml
   - networking/httproute.public-site.yaml
+  - cve-2026-31431-monitor.yaml


### PR DESCRIPTION
Introduce a DaemonSet for monitoring the CVE-2026-31431 vulnerability, ensuring that any vulnerable modules loaded in the system are logged.