### PR TITLE
Change namespace of cve-2026-31431 monitor to default

### DIFF
--- a/components/radix-platform/radix-platform/cve-2026-31431-monitor.yaml
+++ b/components/radix-platform/radix-platform/cve-2026-31431-monitor.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cve-2026-31431-monitor
-  namespace: kube-system
+  namespace: default
   labels:
     app: cve-2026-31431-monitor
     purpose: security-monitoring


### PR DESCRIPTION
Update the namespace of the cve-2026-31431 monitor from kube-system to default for better resource management.