### PR TITLE
Change namespace for CVE-2026-31431 monitor and escape variable in script

### DIFF
--- a/components/radix-platform/radix-platform/cve-2026-31431-monitor.yaml
+++ b/components/radix-platform/radix-platform/cve-2026-31431-monitor.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cve-2026-31431-monitor
-  namespace: kube-system
+  namespace: default
   labels:
     app: cve-2026-31431-monitor
     purpose: security-monitoring

--- a/components/radix-platform/radix-platform/cve-2026-31431-monitor.yaml
+++ b/components/radix-platform/radix-platform/cve-2026-31431-monitor.yaml
@@ -30,12 +30,12 @@ spec:
             - |
               MODULES="algif_aead esp4 esp6 rxrpc"
 
-              echo "$(date -Iseconds) INFO: CVE-2026-31431 monitor started. Watching modules: ${MODULES}"
+              echo "$(date -Iseconds) INFO: CVE-2026-31431 monitor started. Watching modules: $${MODULES}"
 
               while true; do
                 for mod in $MODULES; do
-                  if grep -q "^${mod} " /host/proc/modules 2>/dev/null; then
-                    echo "$(date -Iseconds) WARNING: Vulnerable module '${mod}' is loaded"
+                  if grep -q "^$${mod} " /host/proc/modules 2>/dev/null; then
+                    echo "$(date -Iseconds) WARNING: Vulnerable module '$${mod}' is loaded"
                   fi
                 done
                 sleep 10


### PR DESCRIPTION
Update the namespace of the CVE-2026-31431 monitor from kube-system to default and ensure proper escaping of the Flux variable in the monitoring script.