### PR TITLE
fix: define layerSelector for grafana oci helm chart

### DIFF
--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: master
+    branch: fix-grafana-oci-helm-repo
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: fix-grafana-oci-helm-repo
+    branch: master
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/components/third-party/grafana/ociRepo.yaml
+++ b/components/third-party/grafana/ociRepo.yaml
@@ -6,5 +6,8 @@ metadata:
 spec:
   interval: 1m
   url: oci://ghcr.io/grafana-community/helm-charts/grafana
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
   ref:
     tag: ${GRAFANA_VERSION}


### PR DESCRIPTION
The grafana ocirepository fails with failed to extract layer contents from artifact: requires gzip-compressed: body: gzip: invalid header when trying to pull and extract the latest version 12.3.1.

Not quite sure why, but probably because there are multiple layers in the ocirepo, and unless specified, flux selects the first one

Ref https://fluxcd.io/flux/components/helm/helmreleases/#recommended-settings

Tested successfully in dev cluster
