### PR TITLE
feat: Enable new HTTP route for Radix API

### DIFF
--- a/clusters/development/infrastructure/radix-platform/radix-operator.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-operator.yaml
@@ -41,10 +41,7 @@ spec:
                 groups:
                   - a5dfa635-dc00-4a28-9ad9-9e7f1e56919d # Radix Platform Developers
                   - 64b28659-4fe4-4222-8497-85dd7e43e25b # Radix Platform Users
-            radixApiServer:
-              routes:
-                main:
-                  enabled: true
+
       target:
         kind: HelmRelease
         name: radix-operator

--- a/components/radix-platform/radix-operator/helmRelease.yaml
+++ b/components/radix-platform/radix-operator/helmRelease.yaml
@@ -130,7 +130,6 @@ spec:
 
       routes:
         main:
-          enabled: false # change to true when ready
           hostnames:
             - api.${dnsZone}
             - api.${clusterName}.${dnsZone}
@@ -140,6 +139,9 @@ spec:
 
             - server-radix-api-prod.${dnsZone}
             - server-radix-api-prod.${clusterName}.${dnsZone}
+
+      autoscaling:
+        minReplicas: 2
 
       networkPolicy:
         ingress:


### PR DESCRIPTION
Introduce a new HTTP route for the Radix API and enable it for production use. Additionally, set minimum replicas for autoscaling.