### PR TITLE
fix: bump grafana memory requests

### DIFF
--- a/components/third-party/grafana/helmRelease.yaml
+++ b/components/third-party/grafana/helmRelease.yaml
@@ -50,10 +50,10 @@ spec:
     resources:
       limits:
         cpu: 256m
-        memory: 512Mi
+        memory: 1024Mi
       requests:
         cpu: 128m
-        memory: 256Mi
+        memory: 512Mi
 
     ingress:
       enabled: false


### PR DESCRIPTION
fix repeated Grafana "Out Of Memory Killed" restarts