### PR TITLE
Remove workflow_dispatch condition from check-version steps

### DIFF
--- a/.github/workflows/check-version.yaml
+++ b/.github/workflows/check-version.yaml
@@ -26,11 +26,9 @@ jobs:
 
     steps:
       - name: checkout
-        if: github.event_name != 'workflow_dispatch' || inputs.zone == 'all' || inputs.zone == matrix.zone
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set environments
-        if: github.event_name != 'workflow_dispatch' || inputs.zone == 'all' || inputs.zone == matrix.zone
         run: |
           ZONE="${{ matrix.zone }}"
           PR_BRANCH_TEMP="automatic-version-update"
@@ -41,7 +39,6 @@ jobs:
           echo "PR_NAME=${PR_NAME_TEMP} - ${ZONE}" >> $GITHUB_ENV
 
       - name: Check version
-        if: github.event_name != 'workflow_dispatch' || inputs.zone == 'all' || inputs.zone == matrix.zone
         id: checkversion
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/check-version.yaml` workflow by removing redundant `if` conditions from several steps. The workflow logic is now simplified, as the conditional checks for the `zone` input and event type are no longer present on the `checkout`, `Set environments`, and `Check version` steps.

No functional changes are introduced; the workflow steps will always run regardless of the event or input zone.