### PR TITLE
Refactor version update workflows to support automatic third-party up…

### DIFF
--- a/.github/workflows/check-version.yaml
+++ b/.github/workflows/check-version.yaml
@@ -10,6 +10,9 @@ jobs:
   check-version:
     name: Check for new versions (${{ matrix.zone }})
     runs-on: ubuntu-latest
+    concurrency:
+      group: check-version-${{ matrix.zone }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -31,7 +34,7 @@ jobs:
       - name: Set environments
         run: |
           ZONE="${{ matrix.zone }}"
-          PR_BRANCH_TEMP="automatic-version-update"
+          PR_BRANCH_TEMP="automatic-3party-update"
           PR_NAME_TEMP="Automatic Pull Request"
 
           echo "ZONE=${ZONE}" >> $GITHUB_ENV

--- a/.github/workflows/image-update-auto-pr.yaml
+++ b/.github/workflows/image-update-auto-pr.yaml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - 'flux-image-updates-*'
+      - 'automatic-3party-update-*'
+
+concurrency:
+  group: image-update-pr-${{ github.ref_name }}
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/.github/workflows/scripts/create_pr.sh
+++ b/.github/workflows/scripts/create_pr.sh
@@ -10,7 +10,13 @@ function create-pr() {
     retry_nr=$1
     sleep_before_retry=$(($retry_nr * 2))
     if [[ -z "${PR_BRANCH}" ]]; then
-        PR_BRANCH="flux-image-updates"
+        if [[ -n "${GITHUB_REF_NAME}" ]]; then
+            PR_BRANCH="${GITHUB_REF_NAME}"
+        elif [[ -n "${ZONE}" ]]; then
+            PR_BRANCH="automatic-3party-update-${ZONE}"
+        else
+            PR_BRANCH="automatic-3party-update-dev"
+        fi
     fi
 
     if [[ -z "${PR_NAME}" ]]; then
@@ -18,8 +24,8 @@ function create-pr() {
             ZONE=$(echo "${PR_BRANCH}" | sed -E 's/^flux-image-updates-([^-]+)-.*$/\1/')
         fi
 
-        if [[ -z "${ZONE}" && "${PR_BRANCH}" == automatic-version-update-* ]]; then
-            ZONE=$(echo "${PR_BRANCH}" | sed -E 's/^automatic-version-update-([^-]+).*$/\1/')
+        if [[ -z "${ZONE}" && "${PR_BRANCH}" == automatic-3party-update-* ]]; then
+            ZONE=$(echo "${PR_BRANCH}" | sed -E 's/^automatic-3party-update-([^-]+).*$/\1/')
         fi
 
         if [[ -z "${UPDATE_SCOPE}" && "${PR_BRANCH}" == flux-image-updates-* ]]; then
@@ -29,7 +35,7 @@ function create-pr() {
         if [[ "${PR_BRANCH}" == flux-image-updates-* ]]; then
             if [[ -n "${ZONE}" ]]; then
                 if [[ "${UPDATE_SCOPE}" == "third-party" ]]; then
-                    PR_NAME="Flux Image Pull Request - ${ZONE}(fluximage)"
+                    PR_NAME="Flux Image Pull Request - ${ZONE}(flux-policy)"
                 elif [[ "${UPDATE_SCOPE}" == "radix-components" ]]; then
                     PR_NAME="Flux Image Pull Request - ${ZONE}(radix)"
                 else
@@ -38,7 +44,7 @@ function create-pr() {
             else
                 PR_NAME="Flux Image Pull Request"
             fi
-        elif [[ "${PR_BRANCH}" == automatic-version-update-* ]]; then
+        elif [[ "${PR_BRANCH}" == automatic-3party-update-* ]]; then
             if [[ -n "${ZONE}" ]]; then
                 PR_NAME="Automatic Pull Request - ${ZONE}(3party)"
             else

--- a/.github/workflows/scripts/update_components.sh
+++ b/.github/workflows/scripts/update_components.sh
@@ -5,7 +5,11 @@
 # Please update the documentation if any changes are made to this script.
 
 if [[ -z "${PR_BRANCH}" ]]; then
-    PR_BRANCH="flux-image-updates"
+    if [[ -n "${ZONE}" ]]; then
+        PR_BRANCH="automatic-3party-update-${ZONE}"
+    else
+        PR_BRANCH="automatic-3party-update-dev"
+    fi
 fi
 
 if [[ -z "${ZONE}" ]]; then

--- a/components/flux/image-update-automation/imageUpdateAutomation.yaml
+++ b/components/flux/image-update-automation/imageUpdateAutomation.yaml
@@ -39,7 +39,7 @@ spec:
         {{ end -}}
         {{ end -}}
     push:
-      branch: flux-image-updates-${zone}-third-party
+      branch: automatic-3party-update-${zone}
   update:
     path: ${FLUX_CONFIG_PATH}/infrastructure/third-party
     strategy: Setters


### PR DESCRIPTION
This pull request updates the naming conventions and concurrency controls for automated version and image update workflows. The changes standardize the use of `automatic-3party-update` as the branch prefix for third-party updates (replacing `automatic-version-update` and `flux-image-updates` in several places), and introduce improved concurrency handling to avoid overlapping runs in GitHub Actions workflows.

**Workflow and Automation Naming Updates:**

* Changed the default branch names for third-party update automation from `automatic-version-update` and `flux-image-updates` to `automatic-3party-update` in workflow YAML files and shell scripts, ensuring consistent naming across the codebase. [[1]](diffhunk://#diff-cc72b3e56b5a1adeaf5ba86c6f36eedbf269a2ddf534ad7d952a2fe4c3a4ea28L34-R37) [[2]](diffhunk://#diff-863bc64d1f43126223f777ce7ea73a2f2d1c48225982b8a5bad81ab20324a96fL13-R28) [[3]](diffhunk://#diff-863bc64d1f43126223f777ce7ea73a2f2d1c48225982b8a5bad81ab20324a96fL41-R47) [[4]](diffhunk://#diff-30b4602368981503b4f506e31a79ff0106e6a18c1d15f6b0c81e0a74e827e40dL8-R12) [[5]](diffhunk://#diff-e9803f425a403fc180ff441381b2b3361ee5203409b08c6cfca94dddfe6bbf5fL42-R42)

**Concurrency Improvements:**

* Added concurrency groups to the `check-version` and `image-update-auto-pr` workflows to prevent multiple runs for the same zone or branch from overlapping, using `concurrency.group` and `cancel-in-progress: true`. [[1]](diffhunk://#diff-cc72b3e56b5a1adeaf5ba86c6f36eedbf269a2ddf534ad7d952a2fe4c3a4ea28R13-R15) [[2]](diffhunk://#diff-4fedd4bdef9a0a9fe00eac21db67886526ec0cb998b4d46b717c889348a583ceR7-R11)

**Pull Request Metadata Adjustments:**

* Updated logic for generating pull request names and extracting zone information to align with the new branch naming conventions, and clarified the PR name for third-party updates as `(3party)` or `(flux-policy)` where appropriate. [[1]](diffhunk://#diff-863bc64d1f43126223f777ce7ea73a2f2d1c48225982b8a5bad81ab20324a96fL32-R38) [[2]](diffhunk://#diff-863bc64d1f43126223f777ce7ea73a2f2d1c48225982b8a5bad81ab20324a96fL41-R47)

These changes help streamline automation, reduce confusion around branch names, and ensure that workflows do not conflict with each other during automated runs.…dates