### PR TITLE
Run cron every Thursday

### DIFF
--- a/.github/workflows/check-version.yaml
+++ b/.github/workflows/check-version.yaml
@@ -2,7 +2,7 @@ name: Check for new versions
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '0 12 * * *'
+    - cron: '0 12 * * 4'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow schedule. The workflow will now run weekly on Thursdays instead of daily.

* Changed the cron schedule in `.github/workflows/check-version.yaml` to run at 12:00 UTC every Thursday instead of every day.