### PR TITLE
Add new Kustomizations and Helm releases for cost allocation and vuln…

### DIFF
--- a/clusters/development/infrastructure/radix-platform/kustomization.yaml
+++ b/clusters/development/infrastructure/radix-platform/kustomization.yaml
@@ -1,5 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - radix-platform.yaml
+  - radix-acr-cleanup.yaml
+  - radix-cicd-canary.yaml
+  - radix-cluster-cleanup.yaml
+  - radix-cost-allocation.yaml
   - radix-operator.yaml
+  - radix-platform.yaml
+  - radix-vulnerability-scanner.yaml

--- a/clusters/development/infrastructure/radix-platform/radix-acr-cleanup.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-acr-cleanup.yaml
@@ -12,7 +12,7 @@ spec:
   prune: false
   postBuild:
     substitute:
-      RADIX_ACR_CLEANUP_CHART_VERSION: ${RADIX_ACR_CLEANUP_CHART_VERSION:=tba} # From postBuild.yaml
+      RADIX_ACR_CLEANUP_CHART_VERSION: 1.4.2 # {"$imagepolicy": "flux-system:radix-acr-cleanup-chart:tag"}
     substituteFrom:
       - kind: ConfigMap
         name: radix-flux-config

--- a/clusters/development/infrastructure/radix-platform/radix-cicd-canary.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-cicd-canary.yaml
@@ -1,55 +1,54 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: radix-cluster-cleanup
+  name: radix-cicd-canary
   namespace: flux-system
 spec:
   interval: 10m0s
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./components/radix-platform/radix-cluster-cleanup
+  path: ./components/radix-platform/radix-cicd-canary
   prune: false
   postBuild:
     substitute:
-      RADIX_CLUSTER_CLEANUP_CHART_VERSION: ${RADIX_CLUSTER_CLEANUP_CHART_VERSION:=tba} # From postBuild.yaml
+      RADIX_CICD_CANARY_CHART_VERSION: 1.5.3 # {"$imagepolicy": "flux-system:radix-cicd-canary-chart:tag"}
+    substituteFrom:
+      - kind: ConfigMap
+        name: radix-flux-config
   patches:
     - patch: |-
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
-          name: radix-cluster-cleanup
+          name: radix-cicd-canary
+          namespace: radix-cicd-canary
         spec:
           values:
-            cleanupStart: "08:00"
-            cleanupEnd: "16:00"
-            period: 15m
-            command: stop-and-delete-rrs-continuously
-            logLevel: DEBUG
-            resources:
-              limits:
-                cpu: "2"
-                memory: 150Mi
-              requests:
-                cpu: 50m
-                memory: 150Mi
-            securityContext:
-              readOnlyRootFilesystem: true
+            radixApiPrefix: server-radix-api-qa
+            radixWebhookPrefix: webhook-radix-github-webhook-qa
+            clusterFqdn: ${clusterName}.${dnsZone}
+            radixGroups:
+              user: 64b28659-4fe4-4222-8497-85dd7e43e25b
       target:
         kind: HelmRelease
-        name: radix-cluster-cleanup
-        namespace: default
+        name: radix-cicd-canary
+        namespace: radix-cicd-canary
     - patch: |- # We patch the semver.range instead of using postBuild.substitute to avoid the $quote hack when substitution variable contains YAML control characters (> and *) https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-substitution-of-numbers-and-booleans
         apiVersion: image.toolkit.fluxcd.io/v1beta2
         kind: ImagePolicy
         metadata:
-          name: radix-cluster-cleanup-chart
+          name: radix-cicd-canary-chart
           namespace: flux-system
         spec:
+          imageRepositoryRef:
+            name: radix-cicd-canary-chart
           policy:
             semver:
               range: '>=0.0.0-0'
       target:
         kind: ImagePolicy
-        name: radix-cluster-cleanup-chart
-        namespace: flux-system        
+        name: radix-cicd-canary-chart
+        namespace: flux-system
+
+

--- a/clusters/development/infrastructure/radix-platform/radix-cluster-cleanup.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-cluster-cleanup.yaml
@@ -1,37 +1,49 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: radix-cost-allocation
+  name: radix-cluster-cleanup
   namespace: flux-system
 spec:
+  interval: 10m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./components/radix-platform/radix-cluster-cleanup
+  prune: false
   postBuild:
     substitute:
-      RADIX_COST_ALLOCATION_CHART_VERSION: ${RADIX_COST_ALLOCATION_CHART_VERSION:=tba} # From postBuild.yaml
+      RADIX_CLUSTER_CLEANUP_CHART_VERSION: 1.1.3 # {"$imagepolicy": "flux-system:radix-cluster-cleanup-chart:tag"}
   patches:
     - patch: |-
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
-          name: radix-cost-allocation
-          namespace: radix-cost-allocation
+          name: radix-cluster-cleanup
         spec:
           values:
+            cleanupStart: "08:00"
+            cleanupEnd: "16:00"
+            period: 15m
+            command: stop-and-delete-rrs-continuously
+            logLevel: DEBUG
             resources:
               limits:
                 cpu: "2"
-                memory: 100Mi
+                memory: 150Mi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 50m
+                memory: 150Mi
+            securityContext:
+              readOnlyRootFilesystem: true
       target:
         kind: HelmRelease
-        name: radix-cost-allocation
-        namespace: radix-cost-allocation
+        name: radix-cluster-cleanup
+        namespace: default
     - patch: |- # We patch the semver.range instead of using postBuild.substitute to avoid the $quote hack when substitution variable contains YAML control characters (> and *) https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-substitution-of-numbers-and-booleans
         apiVersion: image.toolkit.fluxcd.io/v1beta2
         kind: ImagePolicy
         metadata:
-          name: radix-cost-allocation-chart
+          name: radix-cluster-cleanup-chart
           namespace: flux-system
         spec:
           policy:
@@ -39,5 +51,5 @@ spec:
               range: '>=0.0.0-0'
       target:
         kind: ImagePolicy
-        name: radix-cost-allocation-chart
-        namespace: flux-system
+        name: radix-cluster-cleanup-chart
+        namespace: flux-system        

--- a/clusters/development/infrastructure/radix-platform/radix-cost-allocation.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-cost-allocation.yaml
@@ -1,54 +1,51 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: radix-cicd-canary
+  name: radix-cost-allocation
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 5m
+  path: "./components/radix-platform/radix-cost-allocation-v2"
+  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./components/radix-platform/radix-cicd-canary
-  prune: false
   postBuild:
     substitute:
-      RADIX_CICD_CANARY_CHART_VERSION: ${RADIX_CICD_CANARY_CHART_VERSION:=tba} # From postBuild.yaml
-    substituteFrom:
-      - kind: ConfigMap
-        name: radix-flux-config
+      COST_ALLOCATION_SQL_CLIENT_ID: 89cd29bf-1e13-421c-a383-2492c1150b4c # gitleaks:allow
+      COST_ALLOCATION_SQL_SERVER: sql-radix-cost-allocation-dev.database.windows.net
+      RADIX_COST_ALLOCATION_CHART_VERSION: 1.4.2 # {"$imagepolicy": "flux-system:radix-cost-allocation-chart:tag"}
   patches:
     - patch: |-
         apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
-          name: radix-cicd-canary
-          namespace: radix-cicd-canary
+          name: radix-cost-allocation
+          namespace: radix-cost-allocation
         spec:
           values:
-            radixApiPrefix: server-radix-api-qa
-            radixWebhookPrefix: webhook-radix-github-webhook-qa
-            clusterFqdn: ${clusterName}.${dnsZone}
-            radixGroups:
-              user: 64b28659-4fe4-4222-8497-85dd7e43e25b
+            resources:
+              limits:
+                cpu: "2"
+                memory: 100Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
       target:
         kind: HelmRelease
-        name: radix-cicd-canary
-        namespace: radix-cicd-canary
+        name: radix-cost-allocation
+        namespace: radix-cost-allocation
     - patch: |- # We patch the semver.range instead of using postBuild.substitute to avoid the $quote hack when substitution variable contains YAML control characters (> and *) https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-substitution-of-numbers-and-booleans
         apiVersion: image.toolkit.fluxcd.io/v1beta2
         kind: ImagePolicy
         metadata:
-          name: radix-cicd-canary-chart
+          name: radix-cost-allocation-chart
           namespace: flux-system
         spec:
-          imageRepositoryRef:
-            name: radix-cicd-canary-chart
           policy:
             semver:
               range: '>=0.0.0-0'
       target:
         kind: ImagePolicy
-        name: radix-cicd-canary-chart
+        name: radix-cost-allocation-chart
         namespace: flux-system
-
-

--- a/clusters/development/infrastructure/radix-platform/radix-vulnerability-scanner.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-vulnerability-scanner.yaml
@@ -4,9 +4,23 @@ metadata:
   name: radix-vulnerability-scanner
   namespace: flux-system
 spec:
+  interval: 5m
+  path: "./components/radix-platform/radix-vulnerability-scanner-v2"
+  dependsOn:
+    - name: external-secrets-operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
   postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: radix-flux-config
     substitute:
-      RADIX_VULNERABILITY_SCANNER_CHART_VERSION: ${RADIX_VULNERABILITY_SCANNER_CHART_VERSION:=tba} # From postBuild.yaml
+      radix_acr_repo_url: ${imageRegistry}
+      VULNERABILITY_SCANNER_SQL_CLIENT_ID: 3eb2d577-be3f-43cf-8b12-c516d724d549 # gitleaks:allow
+      VULNERABILITY_SCANNER_SQL_SERVER: sql-radix-vulnerability-scan-dev.database.windows.net
+      RADIX_VULNERABILITY_SCANNER_CHART_VERSION: 1.4.4 # {"$imagepolicy": "flux-system:radix-vulnerability-scanner-chart:tag"}
   patches:
     - patch: |-
         apiVersion: helm.toolkit.fluxcd.io/v2
@@ -17,7 +31,7 @@ spec:
         spec:
           values:
             workloadIdentityRegistries:  
-            - "${radix_acr_repo_url}"
+            - "${imageRegistry}"
             resources:
               limits:
                 cpu: "2"

--- a/clusters/development/infrastructure/radix-platform/radix-vulnerability-scanner.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-vulnerability-scanner.yaml
@@ -29,8 +29,6 @@ spec:
           namespace: radix-vulnerability-scanner
         spec:
           values:
-            workloadIdentityRegistries:  
-            - "${imageRegistry}"
             resources:
               limits:
                 cpu: "2"

--- a/clusters/development/infrastructure/radix-platform/radix-vulnerability-scanner.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-vulnerability-scanner.yaml
@@ -17,7 +17,6 @@ spec:
       - kind: ConfigMap
         name: radix-flux-config
     substitute:
-      radix_acr_repo_url: ${imageRegistry}
       VULNERABILITY_SCANNER_SQL_CLIENT_ID: 3eb2d577-be3f-43cf-8b12-c516d724d549 # gitleaks:allow
       VULNERABILITY_SCANNER_SQL_SERVER: sql-radix-vulnerability-scan-dev.database.windows.net
       RADIX_VULNERABILITY_SCANNER_CHART_VERSION: 1.4.4 # {"$imagepolicy": "flux-system:radix-vulnerability-scanner-chart:tag"}

--- a/clusters/development/kustomization.yaml
+++ b/clusters/development/kustomization.yaml
@@ -7,14 +7,6 @@ resources:
   - ../../components/flux/image-update-automation
   - ../../components/flux/namespaces
   - ../../components/flux/storageclasses
-  - ../../components/radix-platform/radix-cost-allocation
-  - ../../components/radix-platform/radix-vulnerability-scanner
-  - ./overlay/radix-platform/radix-acr-cleanup/radix-acr-cleanup.yaml
-  - ./overlay/radix-platform/radix-cicd-canary/radix-cicd-canary.yaml
-  - ./overlay/radix-platform/radix-cluster-cleanup/radix-cluster-cleanup.yaml
-
 patches:
   - path: ./postBuild.yaml
   - path: ./flux-patches.yaml
-  - path: ./overlay/radix-platform/radix-cost-allocation/patches.yaml
-  - path: ./overlay/radix-platform/radix-vulnerability-scanner/patches.yaml

--- a/clusters/development/postBuild.yaml
+++ b/clusters/development/postBuild.yaml
@@ -9,24 +9,14 @@ spec:
     substitute:
       ACTIVE_CLUSTER: weekly-24
       AZ_RESOURCE_DNS: dev.radix.equinor.com
-      COST_ALLOCATION_SQL_CLIENT_ID: 89cd29bf-1e13-421c-a383-2492c1150b4c # gitleaks:allow
-      COST_ALLOCATION_SQL_SERVER: sql-radix-cost-allocation-dev.database.windows.net
       FLUX_CONFIG_PATH: ./clusters/development
-      RADIX_ACR_CLEANUP_CHART_VERSION: 1.4.2 # {"$imagepolicy": "flux-system:radix-acr-cleanup-chart:tag"}
       radix_acr_repo_url: radixdev.azurecr.io
       RADIX_CACHE_REGISTRY: radixdevcache.azurecr.io # use `cacheRegistry` from configmap instead
-      RADIX_CICD_CANARY_CHART_VERSION: 1.5.3 # {"$imagepolicy": "flux-system:radix-cicd-canary-chart:tag"}
-      RADIX_CLUSTER_CLEANUP_CHART_VERSION: 1.1.3 # {"$imagepolicy": "flux-system:radix-cluster-cleanup-chart:tag"}
-      RADIX_COST_ALLOCATION_CHART_VERSION: 1.4.2 # {"$imagepolicy": "flux-system:radix-cost-allocation-chart:tag"}
-      RADIX_COST_ALLOCATION_TAG: master-2f3d5136-1749723436 # {"$imagepolicy": "flux-system:radix-cost-allocation:tag"}
       RADIX_ENVIRONMENT: dev # dev | prod
-      RADIX_VULNERABILITY_SCANNER_CHART_VERSION: 1.4.4 # {"$imagepolicy": "flux-system:radix-vulnerability-scanner-chart:tag"}
       RADIX_WILDCARD_CERTIFICATE_ISSUER: letsencrypt-dns01
       RADIX_ZONE_MIGRATE: dev
       RADIX_ZONE: dev # dev | playground | prod
       TEKTON_VERSION: v0.53.0
-      VULNERABILITY_SCANNER_SQL_CLIENT_ID: 3eb2d577-be3f-43cf-8b12-c516d724d549 # gitleaks:allow
-      VULNERABILITY_SCANNER_SQL_SERVER: sql-radix-vulnerability-scan-dev.database.windows.net
     substituteFrom:
       - kind: ConfigMap
         name: radix-flux-config

--- a/components/radix-platform/radix-cost-allocation-v2/helmRelease.yaml
+++ b/components/radix-platform/radix-cost-allocation-v2/helmRelease.yaml
@@ -1,0 +1,36 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: radix-cost-allocation
+  namespace: radix-cost-allocation
+spec:
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  chartRef:
+    kind: OCIRepository
+    name: radix-cost-allocation-chart
+    namespace: flux-system
+  values:
+    db:
+      server: ${COST_ALLOCATION_SQL_SERVER}
+      database: sqldb-radix-cost-allocation
+    podLabels:
+      azure.workload.identity/use: "true"
+    serviceAccount:
+      annotations:
+        azure.workload.identity/client-id: ${COST_ALLOCATION_SQL_CLIENT_ID}
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - arm64

--- a/components/radix-platform/radix-cost-allocation-v2/imagePolicy.yaml
+++ b/components/radix-platform/radix-cost-allocation-v2/imagePolicy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: radix-cost-allocation-chart
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: radix-cost-allocation-chart
+  policy:
+    semver:
+      range: '>=0.0.0'

--- a/components/radix-platform/radix-cost-allocation-v2/imageRepo.yaml
+++ b/components/radix-platform/radix-cost-allocation-v2/imageRepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: radix-cost-allocation-chart
+  namespace: flux-system
+spec:
+  image: ghcr.io/equinor/radix/charts/radix-cost-allocation
+  interval: 1m0s

--- a/components/radix-platform/radix-cost-allocation-v2/kustomization.yaml
+++ b/components/radix-platform/radix-cost-allocation-v2/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- ociRepo.yaml
+- helmRelease.yaml
+- imageRepo.yaml
+- imagePolicy.yaml

--- a/components/radix-platform/radix-cost-allocation-v2/namespace.yaml
+++ b/components/radix-platform/radix-cost-allocation-v2/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: radix-cost-allocation

--- a/components/radix-platform/radix-cost-allocation-v2/ociRepo.yaml
+++ b/components/radix-platform/radix-cost-allocation-v2/ociRepo.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: radix-cost-allocation-chart
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: oci://ghcr.io/equinor/radix/charts/radix-cost-allocation
+  ref:
+    tag: ${RADIX_COST_ALLOCATION_CHART_VERSION} # Set in cluster postBuild.yaml

--- a/components/radix-platform/radix-vulnerability-scanner-v2/helmRelease.yaml
+++ b/components/radix-platform/radix-vulnerability-scanner-v2/helmRelease.yaml
@@ -1,0 +1,44 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: radix-vulnerability-scanner
+  namespace: radix-vulnerability-scanner
+spec:
+  releaseName: radix-vulnerability-scanner
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  chartRef:
+    kind: OCIRepository
+    name: radix-vulnerability-scanner-chart
+    namespace: flux-system
+  values:
+    dockerSecret:
+      create: false
+    sql:
+      serverName: ${VULNERABILITY_SCANNER_SQL_SERVER}
+      databaseName: radix-vulnerability-scan
+    podLabels:
+      azure.workload.identity/use: "true"
+    serviceAccount:
+      annotations:
+        azure.workload.identity/client-id: ${VULNERABILITY_SCANNER_SQL_CLIENT_ID}
+    appNameExcludeList:
+      - canarycicd-test1
+      - canarycicd-test2
+      - canarycicd-test3
+      - canarycicd-test4
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - arm64

--- a/components/radix-platform/radix-vulnerability-scanner-v2/helmRelease.yaml
+++ b/components/radix-platform/radix-vulnerability-scanner-v2/helmRelease.yaml
@@ -14,6 +14,8 @@ spec:
     name: radix-vulnerability-scanner-chart
     namespace: flux-system
   values:
+    workloadIdentityRegistries:
+    - "${imageRegistry}"
     dockerSecret:
       create: false
     sql:

--- a/components/radix-platform/radix-vulnerability-scanner-v2/imagePolicy.yaml
+++ b/components/radix-platform/radix-vulnerability-scanner-v2/imagePolicy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: radix-vulnerability-scanner-chart
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: radix-vulnerability-scanner-chart
+  policy:
+    semver:
+      range: '>=0.0.0'

--- a/components/radix-platform/radix-vulnerability-scanner-v2/imageRepo.yaml
+++ b/components/radix-platform/radix-vulnerability-scanner-v2/imageRepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: radix-vulnerability-scanner-chart
+  namespace: flux-system
+spec:
+  image: ghcr.io/equinor/radix/charts/radix-vulnerability-scanner
+  interval: 1m0s

--- a/components/radix-platform/radix-vulnerability-scanner-v2/kustomization.yaml
+++ b/components/radix-platform/radix-vulnerability-scanner-v2/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- ociRepo.yaml
+- helmRelease.yaml
+- imageRepo.yaml
+- imagePolicy.yaml

--- a/components/radix-platform/radix-vulnerability-scanner-v2/namespace.yaml
+++ b/components/radix-platform/radix-vulnerability-scanner-v2/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: radix-vulnerability-scanner

--- a/components/radix-platform/radix-vulnerability-scanner-v2/ociRepo.yaml
+++ b/components/radix-platform/radix-vulnerability-scanner-v2/ociRepo.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: radix-vulnerability-scanner-chart
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: oci://ghcr.io/equinor/radix/charts/radix-vulnerability-scanner
+  ref:
+    tag: ${RADIX_VULNERABILITY_SCANNER_CHART_VERSION} # Set in cluster postBuild.yaml


### PR DESCRIPTION
This pull request refactors the way the Radix Cost Allocation and Vulnerability Scanner components are managed in the development cluster by migrating them to new v2 component directories, updating their configuration to use Flux OCIRepository and HelmRelease resources, and cleaning up legacy overlay references. It also updates chart versions and improves the organization of kustomization files for better maintainability and clarity.

**Component migration and modernization:**

* Added new v2 directories for `radix-cost-allocation` and `radix-vulnerability-scanner` under `components/radix-platform/`, each with their own `kustomization.yaml`, Flux `OCIRepository`, `HelmRelease`, `ImageRepository`, and `ImagePolicy` resources, as well as dedicated namespaces. This enables better modularization and use of modern Flux patterns. [[1]](diffhunk://#diff-444b83e4d5c27a375fa0e050144da922e501005fe75041dc90138714579da591R1-R8) [[2]](diffhunk://#diff-5195440901732ac79997ea5548b0b3ef67081ef94c2cf34d15962299d03165ecR1-R36) [[3]](diffhunk://#diff-0fea3f20a405a70b784265410c6c804f8001f37c1efb8e850d693c6322e40ebbR1-R10) [[4]](diffhunk://#diff-95a2475bc11112ee0bd033ef7f4218343e0cfe42737f4bb7a66bce3a4fbcc62aR1-R8) [[5]](diffhunk://#diff-5364067337c203eb45f96dac47ef56181a61d8e824d86000c3d9fd9a97233829R1-R11) [[6]](diffhunk://#diff-7c6fb9edb5ad83bd440700a8ff286220b15a0f1c1bf9b07a89989ec0eb6658fbR1-R4) [[7]](diffhunk://#diff-9868dbe781f4ba3ba801ece51ebbd883801cf0cacae38b451ca46ec7bf954120R1-R8) [[8]](diffhunk://#diff-623d42e717e799e2ee17522bb7e4f83a599c87bf66df90193a0d4e53a0a269cfR1-R44) [[9]](diffhunk://#diff-4db4cc1a0f54bc70245544257577ec1e25baece5fe96b28a221efb5afd4cae37R1-R10) [[10]](diffhunk://#diff-645986f4b3c8fe3195e3ef4e3f4921e6bf2720102cd57a16426d4be219b0885dR1-R8) [[11]](diffhunk://#diff-846e494304c2aca990854a1c70271b2333f93027b8e8d475867345409f668589R1-R11) [[12]](diffhunk://#diff-5782363d3155db3e90bfdc6db8923cb7319752a5939a7e125b0a27ac492ed7baR1-R4)

* Updated the main development cluster kustomization (`clusters/development/kustomization.yaml`) to reference the new component locations and removed legacy overlays and patch references.

**Configuration and versioning improvements:**

* Updated chart versions for `radix-acr-cleanup`, `radix-cicd-canary`, `radix-cluster-cleanup`, `radix-cost-allocation`, and `radix-vulnerability-scanner` to use explicit versions and image policies, replacing variable substitution with static values for clarity and reproducibility. [[1]](diffhunk://#diff-73aadb3c03da9a4bae74b1573e2d3675f334275c9f838d6914a6b52004bc4036L15-R15) [[2]](diffhunk://#diff-621e85a64d73a0c940379725dcaa983f2b6c1d88eb2671769c3c786d53cf3e94L15-R15) [[3]](diffhunk://#diff-0206c7dcee1699a65c536764740fbde56208f941af2f845b9ef9763fe5b2dfbaL15-R15) [[4]](diffhunk://#diff-2d9c435f854c4b389c240c2141586c5c6ffa13128a20471a5934e28fc91d9b88R7-R17) [[5]](diffhunk://#diff-82bd93de85d941822e0e8f99175a66d2907b80a6f27e47dac6045b279de3c2f5R7-R23)

* Removed now-unnecessary chart version and secret substitutions from `postBuild.yaml`, as these are now managed within the new component kustomizations.

**Kustomization structure updates:**

* Updated `clusters/development/infrastructure/radix-platform/kustomization.yaml` to include the new component manifests and ensure all relevant resources are applied in the correct order.

**Configuration enhancements:**

* Added new fields such as `interval`, `path`, `prune`, and `sourceRef` in the kustomizations for the new components, and improved the use of `substituteFrom` to pull configuration from a central config map. [[1]](diffhunk://#diff-2d9c435f854c4b389c240c2141586c5c6ffa13128a20471a5934e28fc91d9b88R7-R17) [[2]](diffhunk://#diff-82bd93de85d941822e0e8f99175a66d2907b80a6f27e47dac6045b279de3c2f5R7-R23)

* Fixed the registry reference for workload identity in the vulnerability scanner configuration to use the correct variable.…erability scanning