### PR TITLE
fix: Enable GitHub webhook in Radix API server for all environments

### DIFF
--- a/clusters/development/infrastructure/radix-platform/radix-operator.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-operator.yaml
@@ -41,12 +41,6 @@ spec:
                 groups:
                   - a5dfa635-dc00-4a28-9ad9-9e7f1e56919d # Radix Platform Developers
                   - 64b28659-4fe4-4222-8497-85dd7e43e25b # Radix Platform Users
-            radixApiServer:
-              routes:
-                legacy-github-webhook:
-                  enabled: true
-                webhook-health:
-                  enabled: true
       target:
         kind: HelmRelease
         name: radix-operator

--- a/clusters/playground/infrastructure/radix-platform/radix-operator.yaml
+++ b/clusters/playground/infrastructure/radix-platform/radix-operator.yaml
@@ -42,12 +42,6 @@ spec:
                   - 4b8ec60e-714c-4a9d-8e0a-3e4cfb3c3d31 # Radix Playground Users
                   - 64b28659-4fe4-4222-8497-85dd7e43e25b # Radix Platform Users
                   - 4e1761bc-0c4f-4672-a16d-7f3d8608e366 # AZAPPL Radix Platform
-            radixApiServer:
-              routes:
-                legacy-github-webhook:
-                  enabled: true
-                webhook-health:
-                  enabled: true
             radixWebhook:
               requireAdGroups: false
               requireConfigurationItem: false

--- a/components/radix-platform/radix-operator/helmRelease.yaml
+++ b/components/radix-platform/radix-operator/helmRelease.yaml
@@ -130,6 +130,7 @@ spec:
 
       routes:
         main:
+          enabled: true
           hostnames:
             - api.${dnsZone}
             - api.${clusterName}.${dnsZone}
@@ -142,7 +143,7 @@ spec:
 
         # https://webhook.dev.radix.equinor.com/events/github?appName=XXXX
         legacy-github-webhook:
-          enabled: false
+          enabled: true
           hostnames:
             - webhook.${dnsZone}
             - webhook.${clusterName}.${dnsZone}
@@ -176,7 +177,7 @@ spec:
                   type: ReplaceFullPath
 
         webhook-health:
-          enabled: false
+          enabled: true
           hostnames:
             - webhook.${dnsZone}
             - webhook.${clusterName}.${dnsZone}


### PR DESCRIPTION
Enable the GitHub webhook and health check routes in the Radix API server configuration across all environments. This change ensures that the necessary webhooks are active for proper integration.