### PR TITLE
fix: Cleanup createApp roles in dev environment

### DIFF
--- a/clusters/development/infrastructure/radix-platform/radix-cicd-canary.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-cicd-canary.yaml
@@ -29,7 +29,7 @@ spec:
             radixWebhookPrefix: webhook-radix-github-webhook-qa
             clusterFqdn: ${clusterName}.${dnsZone}
             radixGroups:
-              user: 4b8ec60e-714c-4a9d-8e0a-3e4cfb3c3d31
+              user: ec8c30af-ffb6-4928-9c5c-4abf6ae6f82e # Radix
       target:
         kind: HelmRelease
         name: radix-cicd-canary

--- a/clusters/development/infrastructure/radix-platform/radix-operator.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-operator.yaml
@@ -39,8 +39,6 @@ spec:
             rbac:
               createApp:
                 groups:
-                  - a5dfa635-dc00-4a28-9ad9-9e7f1e56919d # Radix Platform Developers
-                  - 64b28659-4fe4-4222-8497-85dd7e43e25b # Radix Platform Users
                   - 0095272d-cb0a-4284-b1b5-86787b692627 # AZAPPL S941 - Contributor
                   - ec8c30af-ffb6-4928-9c5c-4abf6ae6f82e # Radix
       target:


### PR DESCRIPTION
Remove unnecessary roles from the createApp configuration in the development environment to streamline access control.