### PR TITLE
feat: Remove postBuild and add ACR helm variable

### DIFF
--- a/clusters/c2-production/infrastructure/third-party/image-update-automation.yaml
+++ b/clusters/c2-production/infrastructure/third-party/image-update-automation.yaml
@@ -1,10 +1,15 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: flux-system
+  name: image-update-automation
   namespace: flux-system
 spec:
-  prune: false
+  interval: 5m
+  path: "./components/flux/image-update-automation"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
   postBuild:
     substitute:
       FLUX_CONFIG_PATH: ./clusters/c2-production

--- a/clusters/c2-production/infrastructure/third-party/kustomization.yaml
+++ b/clusters/c2-production/infrastructure/third-party/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - gateway-api.yaml
   - gateway-lb.yaml
   - grafana.yaml
+  - image-update-automation.yaml
   - istio-envoyfilter.yaml
   - istio.yaml
   - keda.yaml
@@ -22,4 +23,3 @@ resources:
   - tekton-operator.yaml
   - velero-schedule.yaml
   - velero.yaml
-  

--- a/clusters/c2-production/kustomization.yaml
+++ b/clusters/c2-production/kustomization.yaml
@@ -4,9 +4,6 @@ resources:
   - flux-system
   - ./infrastructure/third-party
   - ./infrastructure/radix-platform
-  - ../../components/flux/image-update-automation
-  - ../../components/flux/namespaces
   - ../../components/flux/storageclasses
 patches:
-  - path: ./postBuild.yaml
   - path: ./flux-patches.yaml

--- a/clusters/c3/infrastructure/third-party/image-update-automation.yaml
+++ b/clusters/c3/infrastructure/third-party/image-update-automation.yaml
@@ -1,10 +1,15 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: flux-system
+  name: image-update-automation
   namespace: flux-system
 spec:
-  prune: false
+  interval: 5m
+  path: "./components/flux/image-update-automation"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
   postBuild:
     substitute:
       FLUX_CONFIG_PATH: ./clusters/c3

--- a/clusters/c3/infrastructure/third-party/kustomization.yaml
+++ b/clusters/c3/infrastructure/third-party/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - gateway-api.yaml
   - gateway-lb.yaml
   - grafana.yaml
+  - image-update-automation.yaml
   - istio-envoyfilter.yaml
   - istio.yaml
   - keda.yaml
@@ -22,4 +23,3 @@ resources:
   - tekton-operator.yaml
   - velero-schedule.yaml
   - velero.yaml
-  

--- a/clusters/c3/kustomization.yaml
+++ b/clusters/c3/kustomization.yaml
@@ -4,9 +4,6 @@ resources:
   - flux-system
   - ./infrastructure/third-party
   - ./infrastructure/radix-platform
-  - ../../components/flux/image-update-automation
-  - ../../components/flux/namespaces
   - ../../components/flux/storageclasses
 patches:
-  - path: ./postBuild.yaml
   - path: ./flux-patches.yaml

--- a/clusters/monitoring/infrastructure/third-party/image-update-automation.yaml
+++ b/clusters/monitoring/infrastructure/third-party/image-update-automation.yaml
@@ -1,15 +1,18 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: flux-system
+  name: image-update-automation
   namespace: flux-system
 spec:
-  prune: false
+  interval: 5m
+  path: "./components/flux/image-update-automation"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
   postBuild:
     substitute:
-      ACTIVE_CLUSTER: ext-mon-11
       FLUX_CONFIG_PATH: ./clusters/monitoring
-      VELERO_MI_CLIENT_ID: 069f097a-be9a-4e59-bffc-9b1e3d5cbbe9
     substituteFrom:
       - kind: ConfigMap
         name: radix-flux-config

--- a/clusters/monitoring/infrastructure/third-party/kustomization.yaml
+++ b/clusters/monitoring/infrastructure/third-party/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - istio-envoyfilter.yaml
   - cert-manager-issuers.yaml
   - cert-manager-certs.yaml
+  - image-update-automation.yaml
   - grafana.yaml
   - kube-prometheus-stack.yaml
   - prometheus-blackbox-exporter.yaml

--- a/clusters/monitoring/kustomization.yaml
+++ b/clusters/monitoring/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - flux-system
   - ./infrastructure/third-party
   - ./infrastructure/radix-platform
-  - ../../components/flux/image-update-automation
   - ../../components/flux/storageclasses
 patches:
-  - path: ./postBuild.yaml
   - path: ./flux-patches.yaml

--- a/clusters/playground/infrastructure/third-party/image-update-automation.yaml
+++ b/clusters/playground/infrastructure/third-party/image-update-automation.yaml
@@ -1,10 +1,15 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: flux-system
+  name: image-update-automation
   namespace: flux-system
 spec:
-  prune: false
+  interval: 5m
+  path: "./components/flux/image-update-automation"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
   postBuild:
     substitute:
       FLUX_CONFIG_PATH: ./clusters/playground

--- a/clusters/playground/infrastructure/third-party/kustomization.yaml
+++ b/clusters/playground/infrastructure/third-party/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - gateway-api.yaml
   - gateway-lb.yaml
   - grafana.yaml
+  - image-update-automation.yaml
   - istio-envoyfilter.yaml
   - istio.yaml
   - keda.yaml
@@ -22,4 +23,3 @@ resources:
   - tekton-operator.yaml
   - velero-schedule.yaml
   - velero.yaml
-  

--- a/clusters/playground/kustomization.yaml
+++ b/clusters/playground/kustomization.yaml
@@ -4,9 +4,6 @@ resources:
   - flux-system
   - ./infrastructure/third-party
   - ./infrastructure/radix-platform
-  - ../../components/flux/image-update-automation
-  - ../../components/flux/namespaces
   - ../../components/flux/storageclasses
 patches:
-  - path: ./postBuild.yaml
   - path: ./flux-patches.yaml

--- a/clusters/production/infrastructure/third-party/image-update-automation.yaml
+++ b/clusters/production/infrastructure/third-party/image-update-automation.yaml
@@ -1,10 +1,15 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: flux-system
+  name: image-update-automation
   namespace: flux-system
 spec:
-  prune: false
+  interval: 5m
+  path: "./components/flux/image-update-automation"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
   postBuild:
     substitute:
       FLUX_CONFIG_PATH: ./clusters/production

--- a/clusters/production/infrastructure/third-party/kustomization.yaml
+++ b/clusters/production/infrastructure/third-party/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - gateway-api.yaml
   - gateway-lb.yaml
   - grafana.yaml
+  - image-update-automation.yaml
   - istio-envoyfilter.yaml
   - istio.yaml
   - keda.yaml
@@ -22,4 +23,3 @@ resources:
   - tekton-operator.yaml
   - velero-schedule.yaml
   - velero.yaml
-  

--- a/clusters/production/kustomization.yaml
+++ b/clusters/production/kustomization.yaml
@@ -4,9 +4,6 @@ resources:
   - flux-system
   - ./infrastructure/third-party
   - ./infrastructure/radix-platform
-  - ../../components/flux/image-update-automation
-  - ../../components/flux/namespaces
   - ../../components/flux/storageclasses
 patches:
-  - path: ./postBuild.yaml
   - path: ./flux-patches.yaml

--- a/components/radix-platform/radix-acr-cleanup/helmRelease.yaml
+++ b/components/radix-platform/radix-acr-cleanup/helmRelease.yaml
@@ -15,6 +15,7 @@ spec:
   values:
     clusterType: ${clusterType} # Read from radix-flux-config configmap
     activeClusterName: ${ACTIVE_CLUSTER} # Set by zone-specific overlay
+    currentClusterName: ${clusterName} # set in radix-flux-config configmap
     registry: ${imageRegistry}
     deleteUntagged: true
     retainLatestUntagged: 0


### PR DESCRIPTION
Update the Kustomization configuration to remove the postBuild section and introduce a new variable for Azure Container Registry (ACR) in the Helm values. This change streamlines the deployment process and enhances configuration management.