### PR TITLE
fix: Remove replicator annotation from certificate

### DIFF
--- a/components/third-party/cert-manager-certs/certificate.yaml
+++ b/components/third-party/cert-manager-certs/certificate.yaml
@@ -6,9 +6,6 @@ metadata:
   namespace: istio-system 
 spec:
   secretName: radix-wildcard-tls-cert
-  secretTemplate:
-    annotations:
-      replicator.v1.mittwald.de/replicate-to-matching: "radix-wildcard-sync=radix-wildcard-tls-cert"
   issuerRef:
     kind: ClusterIssuer
     name: ${RADIX_WILDCARD_CERTIFICATE_ISSUER}


### PR DESCRIPTION
Eliminate the replicator annotation from the certificate's secret template to streamline configuration.