### PR TITLE
fix: Increase memory limit to 1Gi for radix-acr-cleanup

### DIFF
--- a/components/radix-platform/radix-acr-cleanup/helmRelease.yaml
+++ b/components/radix-platform/radix-acr-cleanup/helmRelease.yaml
@@ -68,7 +68,7 @@ spec:
     resources:
       limits:
         cpu: "2"
-        memory: 250Mi
+        memory: 1Gi
       requests:
         cpu: 50m
         memory: 250Mi


### PR DESCRIPTION
Gets OOM killed in platform (north europe)