### PR TITLE
feat: Upgrade Gateway API to v1.5.1 in DEV

### DIFF
--- a/clusters/development/infrastructure/third-party/gateway-api.yaml
+++ b/clusters/development/infrastructure/third-party/gateway-api.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  path: "./components/third-party/gateway-api/v1.4.0"
+  path: "./components/third-party/gateway-api/v1.5.1"
   prune: false
   wait: true
   sourceRef:


### PR DESCRIPTION
Update the path for the Gateway API to version 1.5.1 in the configuration.