### PR TITLE
Upgrade PLAYGROUND to gateway-api v0.5.0

### DIFF
--- a/clusters/playground/infrastructure/third-party/gateway-api.yaml
+++ b/clusters/playground/infrastructure/third-party/gateway-api.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  path: "./components/third-party/gateway-api/v1.4.0"
+  path: "./components/third-party/gateway-api/v1.5.1"
   prune: false
   wait: true
   sourceRef:


### PR DESCRIPTION
Update the gateway-api version in the configuration to ensure compatibility with the latest features and improvements.