### PR TITLE
Update Gateway API to v1.5.1 (c2-production)

### DIFF
--- a/clusters/c2-production/infrastructure/third-party/gateway-api.yaml
+++ b/clusters/c2-production/infrastructure/third-party/gateway-api.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  path: "./components/third-party/gateway-api/v1.4.0"
+  path: "./components/third-party/gateway-api/v1.5.1"
   prune: false
   wait: true
   sourceRef:


### PR DESCRIPTION
Bumps the Gateway API path for the c2-production cluster from `v1.4.0` to `v1.5.1`.