### PR TITLE
2016 1 remove acr config

### DIFF
--- a/components/third-party/externalsecrets/secrets/secrets.yaml
+++ b/components/third-party/externalsecrets/secrets/secrets.yaml
@@ -1,6 +1,31 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  name: radix-sp-acr-azure
+  namespace: default
+spec:
+  secretStoreRef:
+    name: radix-keyvault
+    kind: SecretStore
+  refreshInterval: 5m
+
+  target:
+
+    # Specify a blueprint for the resulting Kind=Secret
+    template:
+
+      # Use inline templates to construct your desired config file that contains your secret
+      data:
+        sp_credentials.json: |    
+          {{ .radix_cr_cicd }}
+  data:
+    - secretKey: radix_cr_cicd
+      remoteRef:
+        key: radix-cr-cicd
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
   name: radix-sp-buildah-azure
   namespace: default
 spec:

--- a/components/third-party/externalsecrets/secrets/secrets.yaml
+++ b/components/third-party/externalsecrets/secrets/secrets.yaml
@@ -1,36 +1,6 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: radix-sp-acr-azure
-  namespace: default
-spec:
-  secretStoreRef:
-    name: radix-keyvault
-    kind: SecretStore
-  refreshInterval: 5m
-
-  target:
-
-    # Specify a blueprint for the resulting Kind=Secret
-    template:
-
-      metadata:
-        annotations:
-          replicator.v1.mittwald.de/replicate-to-matching: radix-env=app
-        labels: {}
-
-      # Use inline templates to construct your desired config file that contains your secret
-      data:
-        sp_credentials.json: |    
-          {{ .radix_cr_cicd }}
-  data:
-    - secretKey: radix_cr_cicd
-      remoteRef:
-        key: radix-cr-cicd
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
   name: radix-sp-buildah-azure
   namespace: default
 spec:
@@ -40,7 +10,6 @@ spec:
   refreshInterval: 5m
   target:
     template:
-
       metadata:
         annotations:
           replicator.v1.mittwald.de/replicate-to-matching: radix-env=app
@@ -49,14 +18,14 @@ spec:
         username: "{{ .username }}"
         password: "{{ .password }}"
   data:
-  - secretKey: username
-    remoteRef:
-      key: radix-cr-cicd
-      property: id
-  - secretKey: password
-    remoteRef:
-      key: radix-cr-cicd
-      property: password
+    - secretKey: username
+      remoteRef:
+        key: radix-cr-cicd
+        property: id
+    - secretKey: password
+      remoteRef:
+        key: radix-cr-cicd
+        property: password
 
 ---
 apiVersion: external-secrets.io/v1
@@ -80,12 +49,12 @@ spec:
       data:
         .dockerconfigjson: '{"auths":{"docker.io":{"username":"{{ .username }}","password":"{{ .password }}","auth":"{{ printf "%s:%s" .username .password | b64enc }}"}}}'
   data:
-  - secretKey: username
-    remoteRef:
-      key: docker-io-auth-username
-  - secretKey: password
-    remoteRef:
-      key: docker-io-auth-access-token
+    - secretKey: username
+      remoteRef:
+        key: docker-io-auth-username
+    - secretKey: password
+      remoteRef:
+        key: docker-io-auth-access-token
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -105,9 +74,9 @@ spec:
         username: "radix-app-registry-secret-${zone}"
         password: "{{ .password }}"
   data:
-  - secretKey: password
-    remoteRef:
-      key: radix-app-registry-secret
+    - secretKey: password
+      remoteRef:
+        key: radix-app-registry-secret
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -137,14 +106,14 @@ spec:
             }
           }
   data:
-  - secretKey: username
-    remoteRef:
-      key: radix-cr-cicd
-      property: id
-  - secretKey: password
-    remoteRef:
-      key: radix-cr-cicd
-      property: password
+    - secretKey: username
+      remoteRef:
+        key: radix-cr-cicd
+        property: id
+    - secretKey: password
+      remoteRef:
+        key: radix-cr-cicd
+        property: password
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -175,14 +144,14 @@ spec:
             }
           }
   data:
-  - secretKey: username
-    remoteRef:
-      key: radix-cr-cicd
-      property: id
-  - secretKey: password
-    remoteRef:
-      key: radix-cr-cicd
-      property: password
+    - secretKey: username
+      remoteRef:
+        key: radix-cr-cicd
+        property: id
+    - secretKey: password
+      remoteRef:
+        key: radix-cr-cicd
+        property: password
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -199,7 +168,7 @@ spec:
       metadata:
         labels: {}
       data:
-        radix-cicd-canary-values.yaml: |    
+        radix-cicd-canary-values.yaml: |
           {{ .radix_cicd_canary_values }}
   data:
     - secretKey: radix_cicd_canary_values


### PR DESCRIPTION
It turns out `radix-acr-cleanup` still uses this secret