### PR TITLE
fix: disable http/1.0 in Istio for dev, playground and ext-mon

### DIFF
--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: master
+    branch: 634-disable-istio-http10-dev
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: 634-disable-istio-http10-dev
+    branch: master
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/infrastructure/third-party/istio.yaml
+++ b/clusters/development/infrastructure/third-party/istio.yaml
@@ -15,3 +15,18 @@ spec:
   postBuild:
     substitute:
       ISTIO_VERSION: 1.30.2 # https://artifacthub.io/packages/helm/istio-official/istiod
+  patches:
+    - target:
+        kind: HelmRelease
+        name: istiod
+        namespace: istio-system
+      patch: |-
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: istiod
+          namespace: istio-system
+        spec:
+          values:
+            env:
+              PILOT_HTTP10: "false"

--- a/clusters/monitoring/infrastructure/third-party/istio.yaml
+++ b/clusters/monitoring/infrastructure/third-party/istio.yaml
@@ -15,3 +15,18 @@ spec:
   postBuild:
     substitute:
       ISTIO_VERSION: 1.30.2 # https://artifacthub.io/packages/helm/istio-official/istiod
+  patches:
+    - target:
+        kind: HelmRelease
+        name: istiod
+        namespace: istio-system
+      patch: |-
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: istiod
+          namespace: istio-system
+        spec:
+          values:
+            env:
+              PILOT_HTTP10: "false"

--- a/clusters/playground/infrastructure/third-party/istio.yaml
+++ b/clusters/playground/infrastructure/third-party/istio.yaml
@@ -15,3 +15,18 @@ spec:
   postBuild:
     substitute:
       ISTIO_VERSION: 1.30.2 # https://artifacthub.io/packages/helm/istio-official/istiod
+  patches:
+    - target:
+        kind: HelmRelease
+        name: istiod
+        namespace: istio-system
+      patch: |-
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: istiod
+          namespace: istio-system
+        spec:
+          values:
+            env:
+              PILOT_HTTP10: "false"


### PR DESCRIPTION
Disable support for HTTP/1.0 protocol in development, playground and ext-mon clusters.

HTTP/1.0 is obsolete and lacks modern expectations (persistent connections by default, reliable Host handling assumptions, etc.).
Keeping legacy protocol paths can increase attack surface and complexity in proxies/load balancers.
Security controls and observability are generally better tested on HTTP/1.1+ / HTTP/2 / HTTP/3 paths.

For typical users and browsers, impact is usually near zero — modern clients use newer protocols.
Potential breakage is mostly limited to:
- Very old embedded devices
- Ancient bots/crawlers
