### PR TITLE
fix: update acr cleanup window for dev

### DIFF
--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: 3675-fix-update-acr-cleanup-window-for-dev
+    branch: master
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/flux-system/gotk-sync.yaml
+++ b/clusters/development/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: master
+    branch: 3675-fix-update-acr-cleanup-window-for-dev
   secretRef:
     name: flux-system
   url: ssh://git@github.com/equinor/radix-flux

--- a/clusters/development/infrastructure/radix-platform/radix-acr-cleanup.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-acr-cleanup.yaml
@@ -27,8 +27,8 @@ spec:
         spec:
           values:
             deleteUntagged: false
-            cleanupStart: "06:00"
-            cleanupEnd: "09:00"
+            cleanupStart: "07:00"
+            cleanupEnd: "10:00"
       target:
         kind: HelmRelease
         name: radix-acr-cleanup

--- a/clusters/development/infrastructure/radix-platform/radix-acr-cleanup.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-acr-cleanup.yaml
@@ -27,6 +27,8 @@ spec:
         spec:
           values:
             deleteUntagged: false
+            cleanupStart: "06:00"
+            cleanupEnd: "09:00"
       target:
         kind: HelmRelease
         name: radix-acr-cleanup


### PR DESCRIPTION
The previous window was when the cluster was stopped, which means that cleanup never happened. Updated window to a time where the cluster is running.