### PR TITLE
fix: Increase CPU limits and requests for kube-state-metrics in dev

### DIFF
--- a/clusters/development/infrastructure/third-party/kube-prometheus-stack.yaml
+++ b/clusters/development/infrastructure/third-party/kube-prometheus-stack.yaml
@@ -71,10 +71,10 @@ spec:
             kube-state-metrics:
               resources:
                 limits:
-                  cpu: 10m
+                  cpu: 50m
                   memory: 256Mi
                 requests:
-                  cpu: 5m
+                  cpu: 10m
                   memory: 64Mi
   wait: true
   timeout: 2m


### PR DESCRIPTION
Limit of 10m is not enough for kube-state-metrics to complete requests from prometheus causing lots of `"Failed to write metrics" err="failed to write help text: write tcp 10.244.4.208:8080->10.244.4.163:37684: write: broken pipe"` errors