### PR TITLE
fix: add substituteFrom configuration to external-secrets-secrets.yaml

### DIFF
--- a/clusters/production/infrastructure/third-party/external-secrets-secrets.yaml
+++ b/clusters/production/infrastructure/third-party/external-secrets-secrets.yaml
@@ -15,5 +15,8 @@ spec:
   postBuild:
     substitute:
       zone: prod
+    substituteFrom:
+      - kind: ConfigMap
+        name: radix-flux-config
   wait: true
   timeout: 2m


### PR DESCRIPTION
This pull request makes a small configuration update to the `external-secrets-secrets.yaml` file. The change adds a `substituteFrom` field to allow values to be sourced from a `ConfigMap`, which can improve flexibility and maintainability of secret management.

Configuration enhancements:

* Added the `substituteFrom` field under `postBuild` to reference the `radix-flux-config` `ConfigMap`, enabling dynamic substitution of configuration values.