### PR TITLE
updates

### DIFF
--- a/clusters/monitoring/infrastructure/third-party/kustomization.yaml
+++ b/clusters/monitoring/infrastructure/third-party/kustomization.yaml
@@ -5,9 +5,7 @@ resources:
   - gateway-lb.yaml
   - istio.yaml
   - cert-manager.yaml
-  - external-secrets-operator.yaml
-  - external-secrets-secrets.yaml
-  - external-secrets-stores.yaml
+  # - external-secrets-operator.yaml
   - istio-envoyfilter.yaml
   - cert-manager-issuers.yaml
   - cert-manager-certs.yaml


### PR DESCRIPTION
This pull request makes a minor change to the `kustomization.yaml` file by commenting out the inclusion of the `external-secrets-operator.yaml` resource and removing the related secrets and stores resources. This will prevent these resources from being deployed as part of the infrastructure.

- Removed external secrets resources:
  * Commented out `external-secrets-operator.yaml` and removed `external-secrets-secrets.yaml` and `external-secrets-stores.yaml` from the `resources` list in `kustomization.yaml`.