### PR TITLE
Cicd canary dependency

### DIFF
--- a/clusters/c2-production/infrastructure/radix-platform/radix-cicd-canary.yaml
+++ b/clusters/c2-production/infrastructure/radix-platform/radix-cicd-canary.yaml
@@ -9,6 +9,8 @@ spec:
     kind: GitRepository
     name: flux-system
   path: ./components/radix-platform/radix-cicd-canary
+  dependsOn:
+    - name: keda
   prune: false
   postBuild:
     substitute:

--- a/clusters/c3/infrastructure/radix-platform/radix-cicd-canary.yaml
+++ b/clusters/c3/infrastructure/radix-platform/radix-cicd-canary.yaml
@@ -9,6 +9,8 @@ spec:
     kind: GitRepository
     name: flux-system
   path: ./components/radix-platform/radix-cicd-canary
+  dependsOn:
+    - name: keda
   prune: false
   postBuild:
     substitute:

--- a/clusters/development/infrastructure/radix-platform/radix-cicd-canary.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-cicd-canary.yaml
@@ -9,6 +9,8 @@ spec:
     kind: GitRepository
     name: flux-system
   path: ./components/radix-platform/radix-cicd-canary
+  dependsOn:
+    - name: keda
   prune: false
   postBuild:
     substitute:

--- a/clusters/playground/infrastructure/radix-platform/radix-cicd-canary.yaml
+++ b/clusters/playground/infrastructure/radix-platform/radix-cicd-canary.yaml
@@ -9,6 +9,8 @@ spec:
     kind: GitRepository
     name: flux-system
   path: ./components/radix-platform/radix-cicd-canary
+  dependsOn:
+    - name: keda
   prune: false
   postBuild:
     substitute:

--- a/clusters/production/infrastructure/radix-platform/radix-cicd-canary.yaml
+++ b/clusters/production/infrastructure/radix-platform/radix-cicd-canary.yaml
@@ -9,6 +9,8 @@ spec:
     kind: GitRepository
     name: flux-system
   path: ./components/radix-platform/radix-cicd-canary
+  dependsOn:
+    - name: keda
   prune: false
   postBuild:
     substitute:


### PR DESCRIPTION
This pull request updates the deployment configuration for the `radix-cicd-canary` component across multiple clusters to ensure it depends on the `keda` resource. This change enforces that `keda` is deployed before `radix-cicd-canary`, improving deployment order and reliability.
