### PR TITLE
Update ACTIVE_CLUSTER to weekly-34 in cleanup config

### DIFF
--- a/clusters/development/infrastructure/radix-platform/radix-acr-cleanup.yaml
+++ b/clusters/development/infrastructure/radix-platform/radix-acr-cleanup.yaml
@@ -13,7 +13,7 @@ spec:
   postBuild:
     substitute:
       RADIX_ACR_CLEANUP_CHART_VERSION: 1.4.4 # {"$imagepolicy": "flux-system:radix-acr-cleanup-chart:tag"}
-      ACTIVE_CLUSTER: weekly-33
+      ACTIVE_CLUSTER: weekly-34
     substituteFrom:
       - kind: ConfigMap
         name: radix-flux-config


### PR DESCRIPTION
This pull request updates the `ACTIVE_CLUSTER` value in the Radix ACR Cleanup pipeline configuration to point to the new cluster. No other changes are included.

* Updated `ACTIVE_CLUSTER` from `weekly-33` to `weekly-34` in `radix-acr-cleanup.yaml` to ensure deployments target the correct cluster.